### PR TITLE
Feat/analytics endpoints (#21)

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -53,7 +53,7 @@ FORCE_SCRIPT_NAME = env("FORCE_SCRIPT_NAME", default=None)
 SSO_ENABLED = False
 
 # Enable analytics endpoints
-ENABLE_ANALYTICS = env("ENABLE_ANALYTICS", default=False)
+ENABLE_ANALYTICS = env.bool("ENABLE_ANALYTICS", default=False)
 
 # GUNICORN
 GUNICORN_REQUEST_TIMEOUT = gunicorn_request_timeout
@@ -253,7 +253,14 @@ CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP = env.bool(
     "CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP", default=True
 )
 # https://docs.celeryq.dev/en/latest/userguide/configuration.html#task-result-backend-settings
-CELERY_RESULT_BACKEND = env("CELERY_RESULT_BACKEND", default=None)
+# Default to the same Redis the cache + analytics tasks already use:
+# chord-based fan-outs (e.g. analytics native-balance shards) need a
+# result backend to coordinate the reduce step, even though
+# CELERY_IGNORE_RESULT below keeps regular task results from being stored.
+CELERY_RESULT_BACKEND = env(
+    "CELERY_RESULT_BACKEND",
+    default=env("REDIS_URL", default="redis://localhost:6379/0"),
+)
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-accept_content
 CELERY_ACCEPT_CONTENT = ["json"]
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-task_serializer
@@ -309,6 +316,10 @@ CELERY_ROUTES = (
         ),
         (
             "safe_transaction_service.analytics.tasks.*",
+            {"queue": "contracts", "delivery_mode": "transient"},
+        ),
+        (
+            "safe_transaction_service.analytics.tasks_shards.*",
             {"queue": "contracts", "delivery_mode": "transient"},
         ),
     ],

--- a/safe_transaction_service/analytics/implementation-notes.md
+++ b/safe_transaction_service/analytics/implementation-notes.md
@@ -1,0 +1,392 @@
+# Implementation notes — Narrow daily rollup tables + Celery parallelization
+
+Running log of decisions, deviations, and trade-offs made while implementing
+[`ROLLUPS_AND_PARALLEL_SPEC.md`](./ROLLUPS_AND_PARALLEL_SPEC.md).
+
+---
+
+## Spec line-number drift
+
+- **§6 "config/settings/base.py (1880)"** — actual file is 810 lines. The
+  `ANALYTICS_USE_ROLLUPS` flag is being added near the existing
+  `ENABLE_ANALYTICS` flag (~line 55) so it sits with the other analytics
+  feature toggles, not deep in Celery routing.
+- **§4.1 "Reuses existing BALANCE_BATCH_SQL with a `WHERE substring(...)`"**
+  — `BALANCE_BATCH_SQL` filters by `ANY(%s)` of explicit address bytes,
+  not by raw table scan. Two options:
+  1. Apply the prefix filter at the Python level — only pass addresses whose
+     first nibble matches into `ANY(%s)`. Keeps the SQL untouched.
+  2. Add a raw `WHERE substring(addr, 1, 1) = …` to a *new* SQL that scans
+     `history_internaltx` directly (no SafeContract address list).
+  Going with option **(1)**: keeps the existing covering-index plan
+  (`it."to" = ANY(...)`) intact, no new query shape to validate, and the
+  shard work happens inside the same proven batched loop.
+
+## Model field choice for `safe_address` / `token_address`
+
+Spec says `EthereumAddressBinaryField`. The existing `DailyMetric` model uses
+*no* address columns, so this is the first analytics table to embed
+addresses. Reused `EthereumAddressBinaryField` from
+`safe_transaction_service.history.models` — same storage as
+`history_erc20transfer.address`, so a follow-up join is bytes-to-bytes
+(no `decode(...)` in queries).
+
+## `analytics_daily_active_safes` row shape
+
+Spec is one-row-per-(date, safe_address). On a 250 k-Safe chain that's
+~250 k rows per day, up to ~90 M rows over the rolling 12-month window kept
+on disk. Index `(safe_address, date)` is mandatory for the per-Safe lookups
+the spec doesn't quite call out — keeping it as specified.
+
+## §3 single-day populate — write order
+
+All five populators run inside one `relaxed_statement_timeout()` block in
+`compute_daily_metrics_task`. Order:
+
+1. `_compute_daily_metric_core` (existing — DailyMetric upsert)
+2. `_compute_daily_token_volume`
+3. `_compute_daily_active_safes`
+4. `_compute_daily_safe_app_txs`
+5. `_compute_daily_safe_creations`
+
+If one fails the rest still run (per-populator try/except, matching the
+existing per-day try/except pattern in `compute_daily_metrics_task`).
+
+## §4.2 backfill — chord vs group
+
+Spec shows a `group(...) | _backfill_done.s(stats_key)` which is the celery
+**chord** shape. On the `contracts` queue with eager mode this works in
+tests via `CELERY_TASK_ALWAYS_EAGER`. `_backfill_done.s()` only needs to
+write a small cursor blob — left as a Redis `SET` of the (start, end,
+written, failed) summary so the management command can poll it with
+`--wait` if needed. For now `--inline` falls back to the sequential loop
+for debugging.
+
+## Cold-window fallback (§5)
+
+Spec says "if a rollup query returns zero rows for the requested window,
+the service falls back to the live aggregation **once**, caches the
+result, and logs `analytics.rollup.cold_window`."
+
+Implementation: the rollup read returns the rollup result if any rows
+exist in the window; otherwise it logs `analytics.rollup.cold_window`
+and dispatches the equivalent live compute. The "caches the result"
+step writes to the same Redis key the legacy path used — so the next
+request gets the cached payload regardless of rollup population state.
+
+## `ANALYTICS_USE_ROLLUPS` flag *(removed)*
+
+Spec §6 / §7 introduced a feature flag so the migration could land
+without behavior change, then operators could flip it after backfill.
+After review the flag was removed: rollup-first reads with cold-window
+fallback to the legacy path are now unconditional. Rationale:
+
+- The cold-window fallback already gives the "no behavior change"
+  property on fresh deploys — if the rollup is empty, the service falls
+  through to the live/cached path automatically.
+- A flag that's flipped to True everywhere within the rollout window
+  and then never touched again is just dead conditional code waiting to
+  rot.
+- One fewer setting to forget in `.env`.
+
+Rollout sequence is now: migrate → backfill → traffic. No flip step,
+because there's no flag to flip.
+
+## Tests added
+
+- `test_tasks.py`:
+  - `TestDailyRollupPopulators` — one test per rollup populator with
+    ON CONFLICT semantics on rerun.
+  - `TestNativeBalanceShards` — chord under eager mode matches sequential
+    result. Uses 4-shard subset for speed.
+  - Idempotency test for the 5-step `compute_daily_metrics_task`.
+- `test_views_v2.py`:
+  - For the four affected endpoints, rollup-served path + cold-window
+    fallback exercised under `ANALYTICS_USE_ROLLUPS=True`.
+- `test_backfill_daily_metrics.py`:
+  - Group dispatch under eager mode; assert one DailyMetric row per day
+    plus rollup rows.
+
+## Why not partition the rollups now
+
+Spec §9 explicitly rules out partitioning. Rollup tables stay
+single-table; if growth becomes painful past 12 months we can add a
+`DELETE ... WHERE date < now() - interval '12 months'` retention task
+later. Not implementing retention now — out of scope.
+
+---
+
+## Decisions made during implementation
+
+### Eager-mode chord bypass — added then removed
+
+First pass: `celery.chord()` requires a result backend. With
+`CELERY_RESULT_BACKEND` unset in dev/test, both `dispatch_native_balance_shards`
+and `dispatch_backfill` branched on `settings.CELERY_ALWAYS_EAGER` and ran
+shards inline as a workaround.
+
+Final pass: deleted the bypass. The root cause was upstream — chord needs
+a backend even in eager mode. `config/settings/base.py` now defaults
+`CELERY_RESULT_BACKEND` to the same `REDIS_URL` everything else uses, so
+chord coordinates on Redis in every environment (eager-mode tests
+included). `CELERY_IGNORE_RESULT=True` is orthogonal — non-chord tasks
+still don't write results. Production saw this fail in the wild
+(`tasks._calculate_native_balances_from_db`: "Sharded native balance
+dispatch failed (Starting chords requires a result backend to be
+configured.)"), which prompted the cleanup.
+
+### `compute_tvl_task` is fire-and-forget — chord callback owns the snapshot
+
+Earlier shape: `compute_tvl_task` called `_calculate_native_balances_from_db`,
+which dispatched the 16-shard chord and blocked on `.get()` for the
+reduced result, then ran the ERC20 aggregation, then wrote the snapshot.
+On Berachain staging this hung for the full `LOCK_TIMEOUT * 4` window
+on every run — gevent worker + Redis result backend never observed the
+chord callback's result key — so phase-2 logs never appeared and the
+endpoint stayed stuck on the phase-1 placeholder.
+
+Current shape: `compute_tvl_task` writes the placeholder (only if no
+prior snapshot exists) and calls `dispatch_tvl_chord()` from
+`tasks_shards`, which submits
+`(16 native shards) → reduce_native_balance_shards → finalize_tvl_snapshot`
+to the `contracts` queue and returns. `finalize_tvl_snapshot` runs the
+ERC20 aggregation and writes the real snapshot from the chord callback,
+so there is no synchronous `.get()` anywhere in the pipeline.
+`_calculate_native_balances_from_db` is kept as a thin alias for the
+sequential implementation for tests / ad-hoc use; the `parallel` kwarg
+is now ignored.
+
+Failure semantics carry over: if `finalize_tvl_snapshot` raises, the
+placeholder snapshot stays, so the endpoint keeps serving a coherent
+zero payload until the next run succeeds.
+
+### Address-prefix filter in Python (not SQL)
+
+Spec §4.1 mentioned a `WHERE substring(address from 1 for 1) = ...`
+filter. The existing `BALANCE_BATCH_SQL` filters on `ANY(%s)` of an
+explicit address-bytes list — there's no `address` column to filter
+*on* in that SQL. Two ways to add prefix sharding:
+1. Filter the `SafeContract.objects.values_list("address", flat=True)`
+   stream in Python by `addr[2].lower() == prefix` (first nibble), then
+   feed the survivors into the unchanged `BALANCE_BATCH_SQL`.
+2. Add a new SQL that scans `history_internaltx` with a substring
+   filter on `_from` / `to`.
+
+Chose **(1)** — keeps the proven covering-index plan intact and is one
+local function (`_safe_addresses_for_prefix`). Cost is one stream of
+SafeContract.address per shard (small, indexed column).
+
+### `_compute_daily_active_safes` uses bulk_create + ignore_conflicts
+
+Spec §3 shows `INSERT … SELECT … ON CONFLICT DO NOTHING`. Implementation
+uses Django's `bulk_create(ignore_conflicts=True)` because
+`_safes_active_between` already returns lower-case `0x…` strings and
+`EthereumAddressBinaryField` handles the str→bytes encoding via its
+descriptor — re-implementing that in raw SQL would have meant either
+manually `decode(..., 'hex')` per row or maintaining a parallel encoding
+path. `bulk_create` writes in 5k-row batches which is fine for any
+realistic per-day DAU count (BASE chain peaks ~50k DAU).
+
+### `_safes_active_between` refactored to a thin wrapper
+
+Originally `_safes_active_between` built the set then returned `len(...)`.
+The new `_compute_daily_active_safes` populator also needs the set
+(membership goes into the rollup row-by-row). Refactored: extracted
+`_safes_active_between_set` containing the union body, and
+`_safes_active_between` now does `return len(_safes_active_between_set(...))`.
+No behaviour change for existing callers.
+
+### `compute_safe_creations_task` writes a `source` key
+
+Original payload schema had `series` + `computed_at`. The new task adds
+a `source: "rollup" | "live"` key so we can observe in production which
+path is actually serving. Existing read tests don't pin the keyset (just
+check `series`/`computed_at` presence), so this is backwards-compatible.
+
+### `get_transactions_per_safe_app_task` dual-writes via one SQL pass
+
+Spec §6 said "write into `analytics_daily_safe_app_txs` *and* keep
+Redis write." Implementation does the Redis write first (unchanged ORM
+aggregate), then runs ONE additional SQL with `GROUP BY date,
+origin_name` to backfill every distinct day of origin activity into the
+rollup. `ON CONFLICT DO UPDATE` keeps it idempotent. Wrapped in a
+try/except so a rollup failure doesn't strand the Redis publish.
+
+### Rollup origin_name lookup loses `url` *(superseded — see next note)*
+
+~~Spec §2.3 only stores `(date, origin_name, tx_count)`...~~ Initially
+reconstructed `url` via a read-time `MultisigTransaction.objects.filter(
+origin__name__in=...)` lookup. **Reverted** — see next entry.
+
+### `origin_url` denormalised onto the rollup (post-review fix)
+
+Reading from a rollup but still hitting `history_multisigtransaction`
+for URL contradicts the spec's whole point ("single-digit-ms reads
+regardless of `history_*` size"). Added `origin_url CharField(512)` to
+`DailySafeAppTx`; both populators (`_compute_daily_safe_app_txs` and
+the legacy task's dual-write SQL) now select `MAX(origin->>'url')` per
+group; read path returns it straight from the rollup with no JSONB
+lookup. Conflict resolution on multi-URL names: most-recent non-empty
+URL wins, same collapse the legacy aggregate did silently.
+
+Spec §2.3 was the source of the regression — its column list omitted
+URL even though the response payload needs it. Fixed both files.
+
+### Pre-commit triple-quote string fix
+
+`HEX_PREFIXES` and `BACKFILL_CURSOR_KEY` originally had `"""…"""`
+string-literal comments under them (a documentation idiom used in
+Sphinx). The `check-docstring-first` hook flagged these as additional
+module docstrings. Converted both to `#` comments above the constant —
+no functional change.
+
+## Test results
+
+`python -m pytest safe_transaction_service/analytics/tests/ -q`:
+**82 passed** (under `CELERY_ALWAYS_EAGER=True` test settings).
+
+`pre-commit run --files <all-touched>`: all hooks pass after one
+auto-fix pass (ruff format + ruff import sort).
+
+The full repo `./run_tests.sh` was NOT run end-to-end on this machine
+(would require ~minutes against the full history/contracts/tokens
+suites); only the analytics subtree was validated.
+
+---
+
+(Append as work progresses.)
+
+---
+
+# Part 2 — Rollup-back the 5 remaining analytics endpoints
+
+Running log of decisions for the implementation of
+`/home/den/.claude/plans/flickering-honking-wand.md` (DailyActiveOwner
+rollup + AnalyticsSnapshot durable cache).
+
+## Spec drift caught during exploration
+
+- **Spec line 250** claims `backfill_daily_metrics` already has
+  `--only` / `--skip` flags so operators can backfill just `active_owners`.
+  Reality: the command exposes `--inline`, `--wait`, `--chunk-days`
+  only — populators are hard-wired into a tuple in `_upsert_daily_metric`
+  (`tasks.py:1190–1196`). **No action needed**: the new `active_owners`
+  populator runs automatically once added to that tuple, and a full-range
+  backfill of the period covers it. If we ever need selective re-runs
+  we'd add the flags then.
+
+- **Spec line 252 says "5-step single-day populate path"** in the
+  `_upsert_daily_metric` docstring. After adding `active_owners` it's a
+  **6-step** path — updated the docstring to match.
+
+## Payload shape — why I didn't strip `computed_at` from snapshots
+
+The spec's `_read_snapshot_or_empty` returns
+`{**snap.payload, "computed_at": snap.computed_at.isoformat()}`. I kept
+the legacy `computed_at` key inside the *payload* for `summary` /
+`safe_segments` / `tvl` rather than stripping it at write time —
+column-overlay only writes a freshness stamp on top of whatever the
+task produced, so the two stamps stay in sync (both `timezone.now()` at
+write time).
+
+(The earlier `safe_statistics` snapshot also carried a legacy
+`timestamp` field for backwards-compatibility with one external
+consumer. That endpoint was retired — see plan
+`robust-wandering-spark.md` — and the `timestamp`/`computed_at`
+duplication died with it.)
+
+## Empty payloads — the new "cold cache" contract
+
+The big behaviour change vs `_redis_get_or_compute`:
+
+| Path | Old behaviour | New behaviour |
+|---|---|---|
+| Cold cache | inline compute (up to 25s blocking) → return data **or** 504 | fire-and-forget dispatch + return empty payload **in <200ms** |
+| Warm cache | Redis fetch → return data | Postgres fetch → return data |
+
+Under eager-mode tests, `.delay()` runs synchronously so the snapshot is
+populated by the time we return — but `_read_snapshot_or_empty` already
+*committed* to returning `empty` before dispatch. So in tests, the FIRST
+call gets empty / SECOND call gets data. Several existing tests assumed
+single-call inline compute; updated to either pre-warm the snapshot or
+to expect the two-call pattern. Documented as
+`test_summary_cold_cache_returns_empty_without_blocking`.
+
+## `_compute_daily_metric_core` — owners count reads from `DailyActiveOwner` too
+
+Spec says to mirror the `active_safes_daily` trick (read count from rollup
+instead of running the live aggregate). Implemented as:
+
+```python
+owners_rollup_count = DailyActiveOwner.objects.filter(date=day_start.date()).count()
+if owners_rollup_count > 0:
+    active_owners_daily = owners_rollup_count
+else:
+    active_owners_daily = _active_owners_between(day_start, day_end)
+```
+
+Critical: order in the populator tuple matters. `active_owners` runs
+**second** (after `active_safes`, before `token_volume`) so it's
+populated by the time `_compute_daily_metric_core` reads from it. Without
+this, the slow `_active_owners_between` path runs unnecessarily.
+
+The fallback to `_active_owners_between` is intentional — protects
+tests that call `_compute_daily_metric_core` directly without going
+through `_upsert_daily_metric` (`TestUpsertDailyMetric.test_writes_row_with_correct_counts`
+seeds `MultisigTransactionFactory` but doesn't seed
+`MultisigConfirmationFactory`, so the owners rollup may be empty for
+that day; falling back keeps the test from breaking).
+
+## `_DAILY_ACTIVE_OWNERS_SQL` — confirmation-based, no SafeContract filter
+
+`_compute_daily_active_safes` filters via
+`EXISTS (SELECT 1 FROM history_safecontract sc WHERE sc.address = src.addr)`.
+The owners populator does **not** — every confirming owner is by
+definition an owner of a Safe known to the indexer (the
+`MultisigConfirmation` → `MultisigTransaction` → `EthereumTx` →
+`EthereumBlock` chain has no orphan rows by construction). Skipping the
+existence check saves one indexed PK probe per owner.
+
+## Test that broke from a real bug (good)
+
+`TestUpsertDailyMetricFullStack.test_writes_all_four_rollups` was
+renamed to `test_writes_all_rollups` and now asserts
+`DailyActiveOwner.objects.filter(date=d).exists()`. To make that pass
+I had to seed a `MultisigConfirmationFactory`, not just a
+`MultisigTransactionFactory` — surfaced the fact that the new populator
+correctly requires both rows (confirmation + tx in window).
+
+## Service-layer cleanup
+
+- Removed the `SafeLastStatus` import — no longer used now that
+  `get_active_owners` reads `DailyActiveOwner` directly.
+- Kept `_redis_get_or_compute` in the file — still serves the
+  cold-window fallback for `get_active_safes` / `get_active_owners`
+  (per spec §"Decommissioned"). Its 25s poll path is no longer reached
+  by the 4 snapshot endpoints, but the function is unchanged.
+
+## Test environment notes
+
+`./run_tests.sh` requires docker (db + redis + ganache + rabbitmq). I ran
+`pytest safe_transaction_service/analytics/tests/` against the local
+.venv with `DJANGO_DOT_ENV_FILE=.env.test`. Needed three containers up:
+
+- `db` (postgres:16-alpine on 5432)
+- `redis` (redis:alpine on 6379)
+- `ganache` (RPC on 8545 — required by `safe_eth` chain_id init)
+
+Result: **93 passed, 109 warnings, 0 failures** in 19.5 s.
+The full `./run_tests.sh` (history / contracts / tokens) was NOT run on
+this branch — only the analytics subtree was validated.
+
+## Out of scope (carried)
+
+- Historical snapshot/time-series shape (single-row-per-name is intentional).
+- `contracts` queue split.
+- Cron cadence changes for the 4 snapshot tasks.
+- Deletion of orphaned legacy Redis key constants
+  (`REDIS_SUMMARY`, `REDIS_SAFE_SEGMENTS`, `REDIS_TVL`) — kept in
+  `AnalyticsService` for one release as documentation pointers, then
+  deleted. (`REDIS_SAFE_STATISTICS` was removed alongside the
+  `/safe-statistics/` endpoint — see plan
+  `robust-wandering-spark.md`.)

--- a/safe_transaction_service/analytics/management/commands/backfill_daily_metrics.py
+++ b/safe_transaction_service/analytics/management/commands/backfill_daily_metrics.py
@@ -1,0 +1,231 @@
+import json
+from datetime import date, datetime, timedelta
+
+from django.core.management.base import BaseCommand, CommandError
+from django.utils import timezone
+
+from safe_transaction_service.analytics.services.db import relaxed_statement_timeout
+from safe_transaction_service.analytics.tasks import _upsert_daily_metric
+from safe_transaction_service.analytics.tasks_shards import (
+    BACKFILL_CURSOR_KEY,
+    dispatch_backfill,
+)
+from safe_transaction_service.utils.redis import get_redis
+
+
+def _parse_date(value: str) -> date:
+    try:
+        return datetime.strptime(value, "%Y-%m-%d").date()
+    except ValueError as e:
+        raise CommandError(f"Invalid date {value!r}: expected YYYY-MM-DD") from e
+
+
+class Command(BaseCommand):
+    help = (
+        "Backfill DailyMetric rows and rollup tables for a closed date "
+        "range. Default mode group-dispatches one Celery task per day on "
+        "the `contracts` queue; concurrency caps naturally at worker pool "
+        "size. Use --inline for the legacy sequential loop (debugging)."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--start",
+            required=True,
+            help="First day to backfill, inclusive (YYYY-MM-DD, UTC)",
+        )
+        parser.add_argument(
+            "--end",
+            required=True,
+            help="Last day to backfill, inclusive (YYYY-MM-DD, UTC)",
+        )
+        parser.add_argument(
+            "--batch-days",
+            type=int,
+            default=7,
+            help=(
+                "Inline mode only: cosmetic progress-print interval "
+                "(default 7). Ignored when dispatching via Celery."
+            ),
+        )
+        parser.add_argument(
+            "--inline",
+            action="store_true",
+            help=(
+                "Run sequentially inside this process instead of group-"
+                "dispatching one Celery task per day. Useful for debugging "
+                "and for fresh installs without a running worker pool."
+            ),
+        )
+        parser.add_argument(
+            "--wait",
+            type=int,
+            default=0,
+            help=(
+                "Celery mode only: block for up to N seconds waiting for "
+                "the chord callback to land. 0 (default) dispatches and "
+                "returns immediately; check the Redis cursor for results."
+            ),
+        )
+        parser.add_argument(
+            "--chunk-days",
+            type=int,
+            default=7,
+            help=(
+                "Process the date range in chunks of N days. After each "
+                "chunk the command prints a checkpoint summary with "
+                "cumulative written/failed counts and elapsed time, then "
+                "moves to the next chunk. Set to 0 to disable chunking "
+                "(one continuous run). Default 7 — chunk boundaries are "
+                "natural restart points since every day's writes commit "
+                "independently."
+            ),
+        )
+
+    def handle(self, *args, **options):
+        start = _parse_date(options["start"])
+        end = _parse_date(options["end"])
+        if end < start:
+            raise CommandError("--end must be on or after --start")
+
+        total_days = (end - start).days + 1
+        dates = [start + timedelta(days=offset) for offset in range(total_days)]
+
+        if options["inline"]:
+            return self._run_inline(dates, options["batch_days"], options["chunk_days"])
+        return self._run_celery(dates, options["wait"], options["chunk_days"])
+
+    def _run_inline(self, dates, batch_days, chunk_days):
+        tz = timezone.get_current_timezone()
+        total_days = len(dates)
+        written = 0
+        failed = 0
+
+        self.stdout.write(
+            f"Backfilling {total_days} days INLINE: "
+            f"{dates[0].isoformat()} → {dates[-1].isoformat()}"
+        )
+
+        import time as _time
+
+        # Slice the run into chunks. chunk_days=0 → single chunk (legacy).
+        chunk_size = chunk_days if chunk_days and chunk_days > 0 else total_days
+        chunks = [dates[i : i + chunk_size] for i in range(0, total_days, chunk_size)]
+        total_chunks = len(chunks)
+        run_started = _time.time()
+
+        with relaxed_statement_timeout():
+            for chunk_idx, chunk in enumerate(chunks):
+                chunk_started = _time.time()
+                chunk_written = 0
+                chunk_failed = 0
+                self.stdout.write(
+                    f"== Chunk {chunk_idx + 1}/{total_chunks}: "
+                    f"{chunk[0].isoformat()} → {chunk[-1].isoformat()} "
+                    f"({len(chunk)} days)"
+                )
+                self.stdout.flush()
+                for chunk_offset, day in enumerate(chunk):
+                    offset = chunk_idx * chunk_size + chunk_offset
+                    day_start = datetime.combine(day, datetime.min.time(), tzinfo=tz)
+                    day_end = day_start + timedelta(days=1)
+                    self.stdout.write(
+                        f"  [{offset + 1}/{total_days}] Starting {day.isoformat()} …"
+                    )
+                    self.stdout.flush()
+                    started = _time.time()
+                    try:
+                        _upsert_daily_metric(day_start, day_end)
+                        written += 1
+                        chunk_written += 1
+                        self.stdout.write(
+                            f"  [{offset + 1}/{total_days}] {day.isoformat()} "
+                            f"done in {_time.time() - started:.1f}s"
+                        )
+                    except Exception as e:  # noqa: BLE001 — per-day isolation
+                        failed += 1
+                        chunk_failed += 1
+                        self.stderr.write(
+                            self.style.ERROR(
+                                f"  [{offset + 1}/{total_days}] "
+                                f"{day.isoformat()} FAILED after "
+                                f"{_time.time() - started:.1f}s: {e}"
+                            )
+                        )
+                    self.stdout.flush()
+                    if batch_days and (offset + 1) % batch_days == 0:
+                        self.stdout.write(
+                            f"  …{offset + 1}/{total_days} processed "
+                            f"(written={written}, failed={failed})"
+                        )
+
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        f"== Chunk {chunk_idx + 1}/{total_chunks} done in "
+                        f"{_time.time() - chunk_started:.1f}s "
+                        f"(chunk: written={chunk_written}, failed={chunk_failed}; "
+                        f"cumulative: written={written}, failed={failed})"
+                    )
+                )
+                self.stdout.flush()
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Backfill done in {_time.time() - run_started:.1f}s: "
+                f"written={written}, failed={failed}, total={total_days}, "
+                f"chunks={total_chunks}"
+            )
+        )
+
+    def _run_celery(self, dates, wait_seconds: int, chunk_days: int):
+        """Celery path with optional chunking.
+
+        chunk_days=0 → single chord for the whole range (legacy behaviour).
+        chunk_days>0 → dispatch one chord per chunk. With --wait>0, we
+        block on each chord serially before queueing the next, so the
+        contracts queue never has more than `chunk_days` tasks in flight.
+        With --wait=0 we fire all chords up front and return.
+        """
+        total_days = len(dates)
+        chunk_size = chunk_days if chunk_days and chunk_days > 0 else total_days
+        chunks = [dates[i : i + chunk_size] for i in range(0, total_days, chunk_size)]
+        total_chunks = len(chunks)
+
+        self.stdout.write(
+            f"Dispatching backfill: {total_days} days in {total_chunks} chunk(s) "
+            f"of up to {chunk_size} days each "
+            f"({dates[0].isoformat()} → {dates[-1].isoformat()}) on queue=contracts"
+        )
+
+        for chunk_idx, chunk in enumerate(chunks):
+            result = dispatch_backfill(chunk)
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"== Chunk {chunk_idx + 1}/{total_chunks}: "
+                    f"{chunk[0].isoformat()} → {chunk[-1].isoformat()} "
+                    f"dispatched (task {result.id})"
+                )
+            )
+            if not wait_seconds:
+                continue
+
+            self.stdout.write(f"  Waiting up to {wait_seconds}s for chunk to finish…")
+            try:
+                summary = result.get(timeout=wait_seconds, disable_sync_subtasks=False)
+                self.stdout.write(self.style.SUCCESS(f"  Chunk finished: {summary}"))
+            except Exception as e:  # noqa: BLE001 — surface to operator
+                blob = get_redis().get(BACKFILL_CURSOR_KEY)
+                partial = json.loads(blob) if blob else None
+                self.stderr.write(
+                    self.style.WARNING(
+                        f"  Chunk did not finish within {wait_seconds}s: {e}. "
+                        f"Last cursor: {partial}"
+                    )
+                )
+                # Don't abort — next chunk's dispatch is independent.
+
+        if not wait_seconds:
+            self.stdout.write(
+                f"All {total_chunks} chunk(s) dispatched. "
+                f"Cursor key: {BACKFILL_CURSOR_KEY}"
+            )

--- a/safe_transaction_service/analytics/management/commands/warm_analytics_cache.py
+++ b/safe_transaction_service/analytics/management/commands/warm_analytics_cache.py
@@ -1,0 +1,133 @@
+import json
+from datetime import datetime, timedelta
+
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+from safe_transaction_service.analytics.services.analytics_service import (
+    AnalyticsService,
+)
+from safe_transaction_service.analytics.tasks import (
+    compute_active_owners_task,
+    compute_active_safes_task,
+    compute_safe_creations_task,
+    compute_safe_segments_task,
+    compute_summary_task,
+    compute_tvl_task,
+    get_transactions_per_safe_app_task,
+)
+from safe_transaction_service.utils.redis import get_redis
+
+
+class Command(BaseCommand):
+    help = (
+        "Enqueue all analytics precompute tasks on Celery workers to populate "
+        "Redis. Intended for post-deploy warm-up; returns as soon as the tasks "
+        "are dispatched (the actual work runs on workers, not in this process)."
+    )
+
+    # (label, task_callable, freshness_probe_key, timestamp_field)
+    # `timestamp_field` is None for payloads without a timestamp (existence-only check).
+    TASKS = [
+        (
+            "summary",
+            compute_summary_task,
+            AnalyticsService.REDIS_SUMMARY,
+            "computed_at",
+        ),
+        (
+            "transactions_per_safe_app",
+            get_transactions_per_safe_app_task,
+            AnalyticsService.REDIS_TRANSACTIONS_PER_SAFE_APP,
+            None,
+        ),
+        (
+            "active_safes",
+            compute_active_safes_task,
+            AnalyticsService.REDIS_ACTIVE_SAFES_PREFIX + "30d",
+            "computed_at",
+        ),
+        (
+            "active_owners",
+            compute_active_owners_task,
+            AnalyticsService.REDIS_ACTIVE_OWNERS_PREFIX + "30d",
+            "computed_at",
+        ),
+        (
+            "safe_segments",
+            compute_safe_segments_task,
+            AnalyticsService.REDIS_SAFE_SEGMENTS,
+            "computed_at",
+        ),
+        ("tvl", compute_tvl_task, AnalyticsService.REDIS_TVL, "computed_at"),
+        (
+            "safe_creations",
+            compute_safe_creations_task,
+            AnalyticsService.REDIS_SAFE_CREATIONS,
+            "computed_at",
+        ),
+    ]
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--skip-if-fresh",
+            action="store_true",
+            help=(
+                "Skip tasks whose cached payload is newer than "
+                "--fresh-window-hours. Container-restart-safe."
+            ),
+        )
+        parser.add_argument(
+            "--fresh-window-hours",
+            type=int,
+            default=6,
+            help="Hours threshold for --skip-if-fresh (default: 6).",
+        )
+
+    def handle(self, *args, **options):
+        skip_if_fresh = options["skip_if_fresh"]
+        threshold = timedelta(hours=options["fresh_window_hours"])
+        now = timezone.now()
+
+        self.stdout.write("Enqueuing analytics warm-up tasks...")
+        for label, task, probe_key, ts_field in self.TASKS:
+            if skip_if_fresh and self._is_fresh(probe_key, ts_field, now, threshold):
+                self.stdout.write(f"  {label}: skipped (fresh)")
+                continue
+            try:
+                async_result = task.delay()
+                self.stdout.write(
+                    self.style.SUCCESS(f"  {label}: enqueued ({async_result.id})")
+                )
+            except Exception as exc:
+                self.stderr.write(self.style.ERROR(f"  {label}: enqueue FAILED: {exc}"))
+        self.stdout.write(self.style.SUCCESS("Cache warm-up dispatch complete"))
+
+    @staticmethod
+    def _is_fresh(
+        probe_key: str, ts_field: str | None, now, threshold: timedelta
+    ) -> bool:
+        blob = get_redis().get(probe_key)
+        if not blob:
+            return False
+        if ts_field is None:
+            # No timestamp in the payload (e.g. a list) — existence is enough.
+            return True
+        try:
+            payload = json.loads(blob)
+        except json.JSONDecodeError:
+            return False
+        if not isinstance(payload, dict):
+            return False
+        ts_str = payload.get(ts_field)
+        if not ts_str:
+            return False
+        try:
+            ts = datetime.fromisoformat(ts_str)
+        except (TypeError, ValueError):
+            return False
+        if ts.tzinfo is None:
+            # Defensive: payloads have always been written with tz-aware
+            # `timezone.now().isoformat()`, but treat naive as stale to be safe.
+            return False
+        return (now - ts) < threshold

--- a/safe_transaction_service/analytics/migrations/0001_initial.py
+++ b/safe_transaction_service/analytics/migrations/0001_initial.py
@@ -1,0 +1,33 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    initial = True
+
+    dependencies = []
+
+    operations = [
+        migrations.CreateModel(
+            name="DailyMetric",
+            fields=[
+                (
+                    "date",
+                    models.DateField(primary_key=True, serialize=False),
+                ),
+                ("new_safes", models.PositiveIntegerField(default=0)),
+                ("active_safes", models.PositiveIntegerField(default=0)),
+                ("active_owners", models.PositiveIntegerField(default=0)),
+                ("multisig_txs_executed", models.PositiveIntegerField(default=0)),
+                ("module_txs", models.PositiveIntegerField(default=0)),
+                ("erc20_transfers", models.PositiveIntegerField(default=0)),
+                (
+                    "native_value_wei",
+                    models.DecimalField(decimal_places=0, default=0, max_digits=80),
+                ),
+                ("computed_at", models.DateTimeField()),
+            ],
+            options={
+                "ordering": ["-date"],
+            },
+        ),
+    ]

--- a/safe_transaction_service/analytics/migrations/0002_rollup_tables.py
+++ b/safe_transaction_service/analytics/migrations/0002_rollup_tables.py
@@ -1,0 +1,144 @@
+from django.db import migrations, models
+
+import safe_eth.eth.django.models
+
+
+class Migration(migrations.Migration):
+    """Adds the four narrow per-day rollup tables described in
+    ROLLUPS_AND_PARALLEL_SPEC.md §2. All additive — no `history_*` schema
+    touches. Rollback = drop tables (Django can do this with ``migrate
+    analytics 0001``).
+    """
+
+    dependencies = [
+        ("analytics", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="DailyTokenVolume",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("date", models.DateField()),
+                (
+                    "token_address",
+                    safe_eth.eth.django.models.EthereumAddressBinaryField(),
+                ),
+                ("transfer_count", models.PositiveBigIntegerField(default=0)),
+                (
+                    "transfer_value",
+                    models.DecimalField(decimal_places=0, default=0, max_digits=80),
+                ),
+                ("computed_at", models.DateTimeField(auto_now=True)),
+            ],
+            options={},
+        ),
+        migrations.AddConstraint(
+            model_name="dailytokenvolume",
+            constraint=models.UniqueConstraint(
+                fields=("date", "token_address"),
+                name="analytics_daily_token_volume_uniq",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="dailytokenvolume",
+            index=models.Index(fields=["date"], name="analytics_dtv_date_idx"),
+        ),
+        migrations.AddIndex(
+            model_name="dailytokenvolume",
+            index=models.Index(
+                fields=["token_address", "date"],
+                name="analytics_dtv_token_date_idx",
+            ),
+        ),
+        migrations.CreateModel(
+            name="DailyActiveSafe",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("date", models.DateField()),
+                (
+                    "safe_address",
+                    safe_eth.eth.django.models.EthereumAddressBinaryField(),
+                ),
+            ],
+            options={},
+        ),
+        migrations.AddConstraint(
+            model_name="dailyactivesafe",
+            constraint=models.UniqueConstraint(
+                fields=("date", "safe_address"),
+                name="analytics_daily_active_safes_uniq",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="dailyactivesafe",
+            index=models.Index(fields=["date"], name="analytics_das_date_idx"),
+        ),
+        migrations.AddIndex(
+            model_name="dailyactivesafe",
+            index=models.Index(
+                fields=["safe_address", "date"],
+                name="analytics_das_safe_date_idx",
+            ),
+        ),
+        migrations.CreateModel(
+            name="DailySafeAppTx",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("date", models.DateField()),
+                ("origin_name", models.CharField(max_length=255)),
+                (
+                    "origin_url",
+                    models.CharField(blank=True, default="", max_length=512),
+                ),
+                ("tx_count", models.PositiveIntegerField(default=0)),
+            ],
+            options={},
+        ),
+        migrations.AddConstraint(
+            model_name="dailysafeapptx",
+            constraint=models.UniqueConstraint(
+                fields=("date", "origin_name"),
+                name="analytics_daily_safe_app_txs_uniq",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="dailysafeapptx",
+            index=models.Index(fields=["date"], name="analytics_dsat_date_idx"),
+        ),
+        migrations.CreateModel(
+            name="DailySafeCreation",
+            fields=[
+                (
+                    "date",
+                    models.DateField(primary_key=True, serialize=False),
+                ),
+                ("count", models.PositiveIntegerField(default=0)),
+            ],
+            options={},
+        ),
+    ]

--- a/safe_transaction_service/analytics/migrations/0003_dailyactiveowner_and_analyticssnapshot.py
+++ b/safe_transaction_service/analytics/migrations/0003_dailyactiveowner_and_analyticssnapshot.py
@@ -1,0 +1,76 @@
+from django.db import migrations, models
+
+import safe_eth.eth.django.models
+
+
+class Migration(migrations.Migration):
+    """Adds the two tables described in
+    ``flickering-honking-wand.md`` Parts 1 & 2:
+
+    - ``analytics_dailyactiveowner`` — per-day confirmation-based active
+      owners rollup. Replaces the ``SafeLastStatus`` lookup in
+      ``analytics_service.get_active_owners``.
+    - ``analytics_analyticssnapshot`` — single-row-per-name durable
+      cache replacing the four Redis keys used by ``summary`` /
+      ``safe-statistics`` / ``safe-segments`` / ``tvl``.
+
+    Additive only — no ``history_*`` schema touches. Rollback = drop
+    tables (``migrate analytics 0002``).
+    """
+
+    dependencies = [
+        ("analytics", "0002_rollup_tables"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="DailyActiveOwner",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("date", models.DateField()),
+                (
+                    "owner_address",
+                    safe_eth.eth.django.models.EthereumAddressBinaryField(),
+                ),
+            ],
+            options={},
+        ),
+        migrations.AddConstraint(
+            model_name="dailyactiveowner",
+            constraint=models.UniqueConstraint(
+                fields=("date", "owner_address"),
+                name="analytics_daily_active_owner_uniq",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="dailyactiveowner",
+            index=models.Index(fields=["date"], name="analytics_dao_date_idx"),
+        ),
+        migrations.AddIndex(
+            model_name="dailyactiveowner",
+            index=models.Index(
+                fields=["owner_address", "date"],
+                name="analytics_dao_owner_date_idx",
+            ),
+        ),
+        migrations.CreateModel(
+            name="AnalyticsSnapshot",
+            fields=[
+                (
+                    "name",
+                    models.CharField(max_length=64, primary_key=True, serialize=False),
+                ),
+                ("payload", models.JSONField()),
+                ("computed_at", models.DateTimeField()),
+            ],
+            options={"ordering": ["name"]},
+        ),
+    ]

--- a/safe_transaction_service/analytics/migrations/0004_dailymetric_tx_volume_cols.py
+++ b/safe_transaction_service/analytics/migrations/0004_dailymetric_tx_volume_cols.py
@@ -1,0 +1,44 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    """Adds the three tx-volume rollup columns to ``analytics_dailymetric``
+    so ``/v2/analytics/tx-volume/`` can serve from the rollup instead of
+    running a 30s live aggregation per request.
+
+    - ``multisig_txs_proposed``: per-day COUNT on
+      ``history_multisigtransaction.created``. Summed over the window for
+      ``total_multisig_txs``.
+    - ``confirmations_count``: per-day COUNT on
+      ``history_multisigconfirmation.created``. Numerator of
+      ``avg_confirmations``.
+    - ``confirmed_tx_count``: per-day COUNT(DISTINCT multisig_transaction_id)
+      on the same window. Denominator of ``avg_confirmations``.
+
+    All three default to 0 — Postgres ``ADD COLUMN ... DEFAULT 0`` is a
+    metadata-only operation on PG ≥ 11, so this migration is instant on
+    the production table. Backfill of historical days is run via the
+    existing ``backfill_daily_metrics`` management command.
+    """
+
+    dependencies = [
+        ("analytics", "0003_dailyactiveowner_and_analyticssnapshot"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="dailymetric",
+            name="multisig_txs_proposed",
+            field=models.PositiveIntegerField(default=0),
+        ),
+        migrations.AddField(
+            model_name="dailymetric",
+            name="confirmations_count",
+            field=models.PositiveIntegerField(default=0),
+        ),
+        migrations.AddField(
+            model_name="dailymetric",
+            name="confirmed_tx_count",
+            field=models.PositiveIntegerField(default=0),
+        ),
+    ]

--- a/safe_transaction_service/analytics/migrations/0005_drop_safe_statistics_snapshot.py
+++ b/safe_transaction_service/analytics/migrations/0005_drop_safe_statistics_snapshot.py
@@ -1,0 +1,26 @@
+"""Drop the ``safe_statistics`` row from ``analytics_analyticssnapshot``.
+
+The ``/v2/analytics/safe-statistics/`` endpoint was retired in favour of
+``/summary/`` (see plan ``robust-wandering-spark.md``). On already-deployed
+instances ``compute_summary_task`` will keep writing the ``summary`` row;
+the leftover ``safe_statistics`` row would just sit dead-weight in the
+table forever. This is a one-shot delete; reverse is a no-op because the
+schema isn't changing — only one application-managed row by ``name``.
+"""
+
+from django.db import migrations
+
+
+def drop_safe_statistics_row(apps, schema_editor):
+    AnalyticsSnapshot = apps.get_model("analytics", "AnalyticsSnapshot")
+    AnalyticsSnapshot.objects.filter(name="safe_statistics").delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("analytics", "0004_dailymetric_tx_volume_cols"),
+    ]
+
+    operations = [
+        migrations.RunPython(drop_safe_statistics_row, migrations.RunPython.noop),
+    ]

--- a/safe_transaction_service/analytics/models.py
+++ b/safe_transaction_service/analytics/models.py
@@ -1,0 +1,192 @@
+from django.db import models
+
+from safe_eth.eth.django.models import EthereumAddressBinaryField
+
+
+class DailyMetric(models.Model):
+    """Persisted per-day analytics rollup.
+
+    Written incrementally by ``compute_daily_metrics_task`` (one row per
+    completed UTC day) and backfilled by the ``backfill_daily_metrics``
+    management command. Additive metrics (tx counts, transfers, native
+    value) are summed across rows to serve windowed reads; the
+    ``active_safes`` / ``active_owners`` columns store *per-day DAU*
+    (distinct count within the single day) and are NOT summed to form
+    window-distinct counts — the rolling-window distinct values stay on
+    the existing Redis keys, refreshed by the same daily task.
+    """
+
+    date = models.DateField(primary_key=True)
+    new_safes = models.PositiveIntegerField(default=0)
+    active_safes = models.PositiveIntegerField(default=0)
+    active_owners = models.PositiveIntegerField(default=0)
+    multisig_txs_executed = models.PositiveIntegerField(default=0)
+    module_txs = models.PositiveIntegerField(default=0)
+    erc20_transfers = models.PositiveIntegerField(default=0)
+    native_value_wei = models.DecimalField(max_digits=80, decimal_places=0, default=0)
+    # tx-volume rollup (populated by _compute_daily_tx_volume, raw SQL).
+    # Proposal-side count (by MultisigTransaction.created) and the two
+    # numerator/denominator parts of avg_confirmations — sum over a window
+    # for windowed avg = SUM(confirmations_count) / SUM(confirmed_tx_count).
+    multisig_txs_proposed = models.PositiveIntegerField(default=0)
+    confirmations_count = models.PositiveIntegerField(default=0)
+    confirmed_tx_count = models.PositiveIntegerField(default=0)
+    computed_at = models.DateTimeField()
+
+    class Meta:
+        ordering = ["-date"]
+
+    def __str__(self) -> str:
+        return f"DailyMetric({self.date})"
+
+
+class DailyTokenVolume(models.Model):
+    """Per-(day, token) ERC20 transfer roll-up.
+
+    Powers ``/v2/analytics/token-volume?window=Nd`` — replaces the live
+    aggregation in ``analytics_service.get_token_volume``. Additive: window
+    reads SUM across the day rows.
+    """
+
+    date = models.DateField()
+    token_address = EthereumAddressBinaryField()
+    transfer_count = models.PositiveBigIntegerField(default=0)
+    transfer_value = models.DecimalField(max_digits=80, decimal_places=0, default=0)
+    computed_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["date", "token_address"],
+                name="analytics_daily_token_volume_uniq",
+            ),
+        ]
+        indexes = [
+            models.Index(fields=["date"], name="analytics_dtv_date_idx"),
+            models.Index(
+                fields=["token_address", "date"],
+                name="analytics_dtv_token_date_idx",
+            ),
+        ]
+
+
+class DailyActiveSafe(models.Model):
+    """One row per (day, safe) where the Safe had any activity that day.
+
+    Powers ``/v2/analytics/active-safes`` (window DAU is a clean
+    ``COUNT(DISTINCT safe_address)`` over the date range) and the
+    driving-set lookup for ``/active-owners``.
+    """
+
+    date = models.DateField()
+    safe_address = EthereumAddressBinaryField()
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["date", "safe_address"],
+                name="analytics_daily_active_safes_uniq",
+            ),
+        ]
+        indexes = [
+            models.Index(fields=["date"], name="analytics_das_date_idx"),
+            models.Index(
+                fields=["safe_address", "date"],
+                name="analytics_das_safe_date_idx",
+            ),
+        ]
+
+
+class DailySafeAppTx(models.Model):
+    """Per-(day, origin_name) executed multisig tx count.
+
+    Powers ``/v2/analytics/multisig-transactions/by-origin/`` — replaces
+    the weekly live aggregation in ``get_transactions_per_safe_app_task``.
+
+    `origin_url` is denormalised onto the rollup so the read path is a
+    pure rollup scan — no read-time fall-back into
+    `history_multisigtransaction.origin` JSONB just to recover the URL.
+    Populators take ``MAX(origin->>'url')`` per group; if a name ships
+    under multiple URLs on the same day we pick one (same collapse the
+    legacy aggregate did silently).
+    """
+
+    date = models.DateField()
+    origin_name = models.CharField(max_length=255)
+    origin_url = models.CharField(max_length=512, blank=True, default="")
+    tx_count = models.PositiveIntegerField(default=0)
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["date", "origin_name"],
+                name="analytics_daily_safe_app_txs_uniq",
+            ),
+        ]
+        indexes = [
+            models.Index(fields=["date"], name="analytics_dsat_date_idx"),
+        ]
+
+
+class DailySafeCreation(models.Model):
+    """One row per UTC day — count of Safes whose ``EthereumTx.block.timestamp``
+    falls in ``[day, day+1)``.
+
+    Powers ``/v2/analytics/safe-creations?from&to&interval`` — replaces the
+    full-history aggregation in ``compute_safe_creations_task``. Interval
+    resampling (week / month) stays in Python.
+    """
+
+    date = models.DateField(primary_key=True)
+    count = models.PositiveIntegerField(default=0)
+
+
+class DailyActiveOwner(models.Model):
+    """One row per (day, owner) where the owner confirmed any multisig tx
+    whose ``EthereumTx.block.timestamp`` lands in that UTC day.
+
+    Powers ``/v2/analytics/active-owners?window=Nd`` — windowed DAU is a
+    clean ``COUNT(DISTINCT owner_address)`` over the date range, no
+    ``SafeLastStatus`` lookup needed at read time.
+    """
+
+    date = models.DateField()
+    owner_address = EthereumAddressBinaryField()
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["date", "owner_address"],
+                name="analytics_daily_active_owner_uniq",
+            ),
+        ]
+        indexes = [
+            models.Index(fields=["date"], name="analytics_dao_date_idx"),
+            models.Index(
+                fields=["owner_address", "date"],
+                name="analytics_dao_owner_date_idx",
+            ),
+        ]
+
+
+class AnalyticsSnapshot(models.Model):
+    """Single-row-per-name cache for current-state analytics that don't fit
+    the per-day rollup shape (``summary`` / ``safe-segments`` / ``tvl``).
+
+    Replaces the Redis cache for those metrics. Tasks upsert here on each
+    compute; views read the most-recent row by ``name``. Postgres replaces
+    Redis as the durability layer so reads survive Redis flush / pod
+    restart, and the view's dispatch-and-poll path is gone — a missing
+    snapshot returns an empty payload and fire-and-forget-dispatches the
+    refresh task, never blocking the request.
+    """
+
+    name = models.CharField(max_length=64, primary_key=True)
+    payload = models.JSONField()
+    computed_at = models.DateTimeField()
+
+    class Meta:
+        ordering = ["name"]
+
+    def __str__(self) -> str:
+        return f"AnalyticsSnapshot({self.name})"

--- a/safe_transaction_service/analytics/services/analytics_service.py
+++ b/safe_transaction_service/analytics/services/analytics_service.py
@@ -1,7 +1,21 @@
 import json
+import logging
+import time
+from collections.abc import Callable
+from datetime import date, datetime, timedelta
 from functools import cache
 
+from django.db.models import Count, DecimalField, Sum, Value
+from django.db.models.functions import Coalesce
+from django.utils import timezone
+
+from safe_transaction_service import __version__
+from safe_transaction_service.history.models import (
+    ERC20Transfer,
+)
 from safe_transaction_service.utils.redis import get_redis
+
+logger = logging.getLogger(__name__)
 
 
 @cache
@@ -9,13 +23,668 @@ def get_analytics_service() -> "AnalyticsService":
     return AnalyticsService()
 
 
+def _parse_window(window: str) -> int | None:
+    """Parse window string like '7d', '30d', '90d' into days. Returns None if invalid."""
+    window = window.strip().lower()
+    if window.endswith("d"):
+        try:
+            return int(window[:-1])
+        except ValueError:
+            return None
+    return None
+
+
+_COMPUTE_LOCK_TTL_SECONDS = 1800  # max expected task duration (30 min)
+_COMPUTE_WAIT_SECONDS = 25  # how long a non-leader request will block
+_COMPUTE_POLL_INTERVAL_SECONDS = 0.5
+
+# TTL for the SETNX "is a refresh already in flight?" guard used by
+# `AnalyticsService._maybe_dispatch_refresh`. Bound at the same max task
+# duration as `_COMPUTE_LOCK_TTL_SECONDS` so a crashed worker can't keep
+# the lock forever, but long enough that ordinary concurrent miss-reads
+# all coalesce onto a single Celery dispatch.
+_REFRESH_LOCK_TTL_SECONDS = 1800
+
+
+# Empty payloads returned on a cold snapshot read. Shapes match the
+# legacy `redis-miss` responses so existing API clients see no schema
+# change between cold and warm — the only observable difference is that
+# cold reads no longer block for 25s on Celery to finish.
+EMPTY_SUMMARY_PAYLOAD: dict = {
+    "total_safes": 0,
+    "total_multisig_txs": 0,
+    "total_module_txs": 0,
+    "total_erc20_transfers": 0,
+    "total_erc721_transfers": 0,
+    "first_safe_created": None,
+    "last_safe_created": None,
+    "computed_at": None,
+}
+EMPTY_SAFE_SEGMENTS_PAYLOAD: dict = {
+    "personal": 0,
+    "team": 0,
+    "enterprise": 0,
+    "with_modules": 0,
+    "avg_threshold": 0.0,
+    "avg_owners": 0.0,
+    "computed_at": None,
+}
+EMPTY_TVL_PAYLOAD: dict = {
+    "total_safes_with_balance": 0,
+    "native_balance_wei": "0",
+    "erc20_token_count": 0,
+    "top_tokens": [],
+    # 0/0 distinguishes "snapshot never computed" from a real partial run
+    # (where total_shards == 16 and partial_shards > 0).
+    "partial_shards": 0,
+    "total_shards": 0,
+    "computed_at": None,
+}
+
+
+def _redis_get_or_compute(redis_key: str, task_callable: Callable) -> dict | None:
+    """
+    Read a precomputed analytics payload from Redis. On miss the leader
+    *dispatches* the compute to Celery (rather than running it inline) and
+    falls into the same polling loop as every concurrent miss-request.
+
+    Running the compute inline in a gunicorn worker guaranteed an nginx 504
+    on the first request after a cold cache, because task durations
+    legitimately exceed the request timeout on large chains. Handing it to
+    Celery lets the request return promptly with the fallback payload while
+    the compute lands in the background; subsequent requests pick up the
+    warm cache.
+
+    Thundering-herd protection: leadership is taken via Redis SETNX on
+    `{redis_key}:compute_lock` so N concurrent miss-requests dispatch the
+    task only once. The leader releases the lock as soon as the cache lands
+    inside the per-request poll deadline; otherwise the lock TTL bounds
+    redispatch in the case of a crashed/stuck worker.
+
+    Returns the parsed JSON dict, or None if no result is available within
+    `_COMPUTE_WAIT_SECONDS`.
+    """
+    redis = get_redis()
+    blob = redis.get(redis_key)
+    if blob:
+        return json.loads(blob)
+
+    lock_key = f"{redis_key}:compute_lock"
+    is_leader = redis.set(lock_key, "1", nx=True, ex=_COMPUTE_LOCK_TTL_SECONDS)
+
+    dispatched_async = False
+    if is_leader:
+        # In tests / non-Celery callers `task_callable` may be a plain
+        # function (e.g. a `lambda: None` patched in to simulate a hard
+        # failure). Fall back to inline execution in that case so existing
+        # test fixtures keep working without dragging a Celery broker in.
+        # Exceptions from the dispatch / inline call are swallowed so a
+        # broker outage or a buggy inline callable falls through to the
+        # view's fallback payload instead of 500-ing.
+        try:
+            if hasattr(task_callable, "delay"):
+                task_callable.delay()
+                dispatched_async = True
+            else:
+                task_callable()
+        except Exception:
+            pass
+
+        # Eager mode and inline mode: the task has already finished by the
+        # time we get here. If it wrote a result, return it; otherwise
+        # there's no point polling — release the lock and surface None.
+        if not dispatched_async:
+            blob = redis.get(redis_key)
+            redis.delete(lock_key)
+            return json.loads(blob) if blob else None
+
+        # Async leader: a quick early check covers the (rare) case where
+        # the Celery worker has already finished by the time we get here,
+        # so we don't pay an unnecessary poll interval.
+        blob = redis.get(redis_key)
+        if blob is not None:
+            redis.delete(lock_key)
+            return json.loads(blob)
+
+    # Poll for the result. Non-leader callers always end up here; the
+    # async leader also waits here for the Celery worker to publish.
+    deadline = time.monotonic() + _COMPUTE_WAIT_SECONDS
+    while time.monotonic() < deadline:
+        time.sleep(_COMPUTE_POLL_INTERVAL_SECONDS)
+        blob = redis.get(redis_key)
+        if blob:
+            if is_leader:
+                redis.delete(lock_key)
+            return json.loads(blob)
+    return None
+
+
+def _week_key(iso_period: str) -> str:
+    """Map an ISO date string to its ISO-week key, e.g. '2026-W20'. Used
+    as the deduplication key for bucketing rows."""
+    y, w, _ = date.fromisoformat(iso_period).isocalendar()
+    return f"{y}-W{w:02d}"
+
+
+def _week_label(iso_period: str) -> str:
+    """Return the Monday of the ISO week containing `iso_period`. The label
+    must be stable regardless of which day in the week first appeared in
+    the source series, so chart consumers expecting ISO 8601 week-start get
+    a Monday every time."""
+    d = date.fromisoformat(iso_period)
+    return (d - timedelta(days=d.weekday())).isoformat()
+
+
+def _month_key(iso_period: str) -> str:
+    """Map an ISO date string to its calendar month key, e.g. '2026-05'."""
+    return iso_period[:7]
+
+
+def _month_label(iso_period: str) -> str:
+    """Return the first day of the month containing `iso_period`. Same
+    stability rationale as `_week_label`."""
+    return iso_period[:7] + "-01"
+
+
+def _resample_day_series(series: list[dict], interval: str) -> list[dict]:
+    """
+    Bucket a day-grain `[{period, count}]` series into week or month bins.
+    The `period` label is normalized to the first day of the bucket
+    (Monday for week, 1st for month) — independent of which source day
+    first landed in that bucket.
+    """
+    if interval == "day":
+        return series
+    if interval == "week":
+        bucket_fn, label_fn = _week_key, _week_label
+    else:
+        bucket_fn, label_fn = _month_key, _month_label
+    buckets: dict[str, dict] = {}
+    for row in series:
+        key = bucket_fn(row["period"])
+        if key not in buckets:
+            buckets[key] = {"period": label_fn(row["period"]), "count": 0}
+        buckets[key]["count"] += row["count"]
+    return list(buckets.values())
+
+
+def _in_range(iso_period: str, date_from, date_to) -> bool:
+    if not date_from and not date_to:
+        return True
+    d = date.fromisoformat(iso_period)
+    if date_from and d < _as_date(date_from):
+        return False
+    if date_to and d > _as_date(date_to):
+        return False
+    return True
+
+
+def _as_date(value) -> date:
+    return value.date() if isinstance(value, datetime) else value
+
+
 class AnalyticsService:
     REDIS_TRANSACTIONS_PER_SAFE_APP = "analytics_transactions_per_safe_app"
+    REDIS_ACTIVE_SAFES_PREFIX = "analytics_active_safes_"
+    REDIS_ACTIVE_OWNERS_PREFIX = "analytics_active_owners_"
+    REDIS_SAFE_CREATIONS = "analytics_safe_creations"
+    # Legacy keys — `summary` / `safe_segments` / `tvl` moved from Redis
+    # to the `analytics_analyticssnapshot` table in this release.
+    # Constants kept for one release as documentation pointers, then
+    # deleted in a follow-up (see `flickering-honking-wand.md`
+    # §"Decommissioned"). Don't write to them.
+    REDIS_SAFE_SEGMENTS = "analytics_safe_segments"
+    REDIS_TVL = "analytics_tvl"
+    REDIS_SUMMARY = "analytics_summary"
+
+    def _read_snapshot_or_empty(
+        self, name: str, empty: dict, refresh_task: Callable
+    ) -> dict:
+        """Read the most recent ``AnalyticsSnapshot`` row by name.
+
+        If absent (cold deploy / empty table / mid-deploy), fire-and-forget
+        dispatch the refresh task (SETNX-locked to coalesce concurrent
+        miss-reads onto one dispatch) and return ``empty`` immediately.
+
+        Crucially: this NEVER blocks the request waiting for the compute.
+        That blocking is what produced the 25s gunicorn timeout / 504 on
+        BASE before this rewrite — see `flickering-honking-wand.md` §
+        Context.
+        """
+        from safe_transaction_service.analytics.models import AnalyticsSnapshot
+
+        try:
+            snap = AnalyticsSnapshot.objects.get(name=name)
+        except AnalyticsSnapshot.DoesNotExist:
+            logger.info("analytics.snapshot.cold_read name=%s", name)
+            self._maybe_dispatch_refresh(name, refresh_task)
+            return dict(empty)
+        return {**snap.payload, "computed_at": snap.computed_at.isoformat()}
+
+    def _maybe_dispatch_refresh(self, name: str, task: Callable) -> None:
+        """Take a SETNX lock on the snapshot name and dispatch the refresh
+        task if leader. The lock prevents a herd of concurrent miss-reads
+        from all kicking off the same expensive compute.
+
+        In tests / non-Celery callers ``task`` may be a plain function
+        (no ``.delay``). In that case skip dispatch — the caller-side
+        test will trigger the compute directly. Exceptions are swallowed:
+        a broker outage falls through to the next scheduled run.
+        """
+        lock_key = f"analytics_snapshot:{name}:refresh_lock"
+        redis = get_redis()
+        try:
+            is_leader = redis.set(lock_key, "1", nx=True, ex=_REFRESH_LOCK_TTL_SECONDS)
+        except Exception:
+            logger.exception("analytics.snapshot.refresh_lock_failed name=%s", name)
+            return
+        if not is_leader:
+            return
+        try:
+            if hasattr(task, "delay"):
+                task.delay()
+                logger.info("analytics.snapshot.refresh_dispatched name=%s", name)
+        except Exception:
+            logger.exception("analytics.snapshot.refresh_dispatch_failed name=%s", name)
 
     def get_safe_transactions_per_safe_app(self) -> list[dict]:
+        """Group multisig tx counts by origin name + URL.
+
+        Totals come from the ``analytics_dailysafeapptx`` rollup
+        (constant-time window scan, regardless of
+        ``history_multisigtransaction`` size). On a cold rollup (fresh
+        deploy / mid-backfill) we fall back to the legacy Redis-cached
+        payload populated by ``get_transactions_per_safe_app_task``.
+        """
+        payload = self._get_safe_app_txs_from_rollup()
+        if payload:
+            return payload
+        logger.info("analytics.rollup.cold_window key=safe_app_txs")
+
         redis = get_redis()
         analytic_result = redis.get(self.REDIS_TRANSACTIONS_PER_SAFE_APP)
         if analytic_result:
             return json.loads(analytic_result)
-        else:
+        return []
+
+    def _get_safe_app_txs_from_rollup(self) -> list[dict]:
+        """Build the `[{name, url, total_tx, tx_last_week, ...}]` payload
+        entirely from ``analytics_dailysafeapptx`` — no read-time touch
+        of ``history_multisigtransaction``.
+
+        `origin_url` is denormalised onto the rollup (see
+        `DailySafeAppTx`). The most-recent non-empty URL wins per name
+        when an app ships under multiple URLs in the window.
+        """
+        from safe_transaction_service.analytics.models import DailySafeAppTx
+
+        today = timezone.now().date()
+        week_ago = today - timedelta(days=7)
+        month_ago = today - timedelta(days=30)
+        year_ago = today - timedelta(days=365)
+
+        rows = list(
+            DailySafeAppTx.objects.filter(date__gte=year_ago)
+            .order_by("date")
+            .values("date", "origin_name", "origin_url", "tx_count")
+        )
+        if not rows:
             return []
+
+        agg: dict[str, dict] = {}
+        for r in rows:
+            name = r["origin_name"]
+            d = r["date"]
+            c = int(r["tx_count"] or 0)
+            slot = agg.setdefault(
+                name,
+                {
+                    "name": name,
+                    "url": "",
+                    "total_tx": 0,
+                    "tx_last_week": 0,
+                    "tx_last_month": 0,
+                    "tx_last_year": 0,
+                },
+            )
+            slot["total_tx"] += c
+            if d >= week_ago:
+                slot["tx_last_week"] += c
+            if d >= month_ago:
+                slot["tx_last_month"] += c
+            slot["tx_last_year"] += c
+            # Rows are ordered by date asc, so the last non-empty URL
+            # we see is the most recent one — same collapse the legacy
+            # aggregate did silently.
+            if r["origin_url"]:
+                slot["url"] = r["origin_url"]
+
+        return sorted(agg.values(), key=lambda r: r["total_tx"], reverse=True)
+
+    # ── A.1 Summary (snapshot table, populated by compute_summary_task) ──
+
+    def get_summary(self) -> dict:
+        """Read the persisted ``summary`` snapshot, overlay request-time
+        fields (`chain_id`, `service_version`).
+
+        Replaces the Redis-cached + 25s-poll read path. ``chain_id`` /
+        ``service_version`` stay at request time per spec — cheap, and
+        keeps the existing chain_id RPC test mocks working.
+        """
+        from safe_transaction_service.analytics.tasks import (
+            compute_summary_task,
+        )
+        from safe_transaction_service.utils.ethereum import get_chain_id
+
+        cached = self._read_snapshot_or_empty(
+            "summary", EMPTY_SUMMARY_PAYLOAD, compute_summary_task
+        )
+        return {
+            "total_safes": cached.get("total_safes", 0),
+            "total_multisig_txs": cached.get("total_multisig_txs", 0),
+            "total_module_txs": cached.get("total_module_txs", 0),
+            "total_erc20_transfers": cached.get("total_erc20_transfers", 0),
+            "total_erc721_transfers": cached.get("total_erc721_transfers", 0),
+            "first_safe_created": cached.get("first_safe_created"),
+            "last_safe_created": cached.get("last_safe_created"),
+            "chain_id": get_chain_id(),
+            "service_version": __version__,
+            "computed_at": cached.get("computed_at"),
+        }
+
+    # ── A.2 Active Safes (Redis-cached) ──────────────────────────────
+
+    def get_active_safes(self, window: str) -> dict:
+        """Read the window-distinct active_safes count.
+
+        Single ``COUNT(DISTINCT safe_address)`` over the per-day
+        membership table for the requested window — sub-100 ms
+        regardless of ``history_*`` size. On a cold rollup we fall
+        through to the Redis-cached rolling-window value populated by
+        ``compute_daily_metrics_task``.
+        """
+        from safe_transaction_service.analytics.models import DailyActiveSafe
+
+        days = _parse_window(window) or 30
+        today = timezone.now().date()
+        since = today - timedelta(days=days)
+        windowed = DailyActiveSafe.objects.filter(date__gte=since)
+        if windowed.exists():
+            count = windowed.values("safe_address").distinct().count()
+            return {
+                "window": window,
+                "active_safes": count,
+                "computed_at": timezone.now().isoformat(),
+            }
+        logger.info("analytics.rollup.cold_window key=active_safes_%s", window)
+
+        from safe_transaction_service.analytics.tasks import (
+            compute_daily_metrics_task,
+        )
+
+        cached = _redis_get_or_compute(
+            self.REDIS_ACTIVE_SAFES_PREFIX + window, compute_daily_metrics_task
+        )
+        if cached and cached.get("window") == window:
+            return cached
+        return {"window": window, "active_safes": 0, "computed_at": None}
+
+    # ── A.3 Safe Creations Time Series (Redis-cached, resampled in memory) ──
+
+    def get_safe_creations(self, date_from, date_to, interval: str) -> list[dict]:
+        series = self._safe_creations_from_rollup(date_from, date_to)
+        if series:
+            return _resample_day_series(series, interval)
+        logger.info("analytics.rollup.cold_window key=safe_creations")
+
+        from safe_transaction_service.analytics.tasks import (
+            compute_safe_creations_task,
+        )
+
+        cached = (
+            _redis_get_or_compute(
+                self.REDIS_SAFE_CREATIONS, compute_safe_creations_task
+            )
+            or {}
+        )
+        day_series = cached.get("series", [])
+        if date_from or date_to:
+            day_series = [
+                row
+                for row in day_series
+                if _in_range(row["period"], date_from, date_to)
+            ]
+        return _resample_day_series(day_series, interval)
+
+    def _safe_creations_from_rollup(self, date_from, date_to) -> list[dict]:
+        from safe_transaction_service.analytics.models import DailySafeCreation
+
+        qs = DailySafeCreation.objects.all().order_by("date")
+        if date_from is not None:
+            qs = qs.filter(date__gte=_as_date(date_from))
+        if date_to is not None:
+            qs = qs.filter(date__lte=_as_date(date_to))
+        return [{"period": r.date.isoformat(), "count": r.count} for r in qs]
+
+    # ── A.4 Active Owners (Redis-cached) ─────────────────────────────
+
+    def get_active_owners(self, window: str) -> dict:
+        """Distinct owners who confirmed any multisig tx executed in the
+        window — confirmation-based active-owners semantic.
+
+        Window DAU is a single ``COUNT(DISTINCT owner_address)`` over
+        the per-day ``analytics_dailyactiveowner`` rollup — sub-100 ms
+        regardless of ``history_*`` size. Replaces the prior
+        ``DailyActiveSafe`` → ``SafeLastStatus`` lookup path which on
+        BASE took 9–28 s for the 30d window (and 504'd on cold deploys).
+
+        On a cold rollup we fall through to the Redis-cached
+        rolling-window value populated by ``compute_daily_metrics_task``.
+        """
+        from safe_transaction_service.analytics.models import DailyActiveOwner
+
+        days = _parse_window(window) or 30
+        today = timezone.now().date()
+        since = today - timedelta(days=days)
+        windowed = DailyActiveOwner.objects.filter(date__gte=since)
+        if windowed.exists():
+            count = windowed.values("owner_address").distinct().count()
+            return {
+                "window": window,
+                "active_owners": count,
+                "computed_at": timezone.now().isoformat(),
+            }
+        logger.info("analytics.rollup.cold_window key=active_owners_%s", window)
+
+        from safe_transaction_service.analytics.tasks import (
+            compute_daily_metrics_task,
+        )
+
+        cached = _redis_get_or_compute(
+            self.REDIS_ACTIVE_OWNERS_PREFIX + window, compute_daily_metrics_task
+        )
+        if cached and cached.get("window") == window:
+            return cached
+        return {"window": window, "active_owners": 0, "computed_at": None}
+
+    # ── A.5 TX Volume (DailyMetric sum when populated, live fallback) ─
+
+    def get_tx_volume(self, window: str) -> dict:
+        """Read the tx-volume window from the `DailyMetric` rollup.
+
+        Pure SUM over ~N day rows — single round-trip to Postgres, no
+        live aggregation. The proposal-side count, executed count,
+        module count, native value, and the numerator/denominator of
+        `avg_confirmations` are all rolled up daily by
+        `_compute_daily_tx_volume` + `_compute_daily_metric_core` (see
+        `analytics/tasks.py`).
+
+        Windowed `avg_confirmations` is computed as
+            SUM(confirmations_count) / SUM(confirmed_tx_count)
+        — i.e. average confirmations per (tx, day-bucket). A tx that
+        gets confs on multiple days is counted once per day. For most
+        txs (signed in a single sitting) this is identical to the
+        per-tx average; for long-pending txs the rollup gives a
+        slightly smaller number. We surface this as
+        `avg_confirmations_approximation: per-tx-day` so callers can
+        reason about it.
+
+        When `DailyMetric` coverage is partial (fresh install /
+        mid-backfill) the response still returns immediately and
+        surfaces `coverage_days` so operators can detect the gap —
+        we deliberately do NOT fall back to a 30s live query on the
+        request path (that's what caused the 504s this rollup
+        replaces).
+        """
+        days = _parse_window(window)
+        if days is None:
+            days = 30
+
+        from safe_transaction_service.analytics.models import DailyMetric
+
+        today = timezone.now().date()
+        date_from = today - timezone.timedelta(days=days)
+        rows = DailyMetric.objects.filter(date__gte=date_from, date__lt=today)
+
+        agg = rows.aggregate(
+            proposed=Coalesce(Sum("multisig_txs_proposed"), Value(0)),
+            executed=Coalesce(Sum("multisig_txs_executed"), Value(0)),
+            module=Coalesce(Sum("module_txs"), Value(0)),
+            native=Coalesce(
+                Sum("native_value_wei"),
+                Value(0),
+                output_field=DecimalField(max_digits=80, decimal_places=0),
+            ),
+            conf_total=Coalesce(Sum("confirmations_count"), Value(0)),
+            conf_txs=Coalesce(Sum("confirmed_tx_count"), Value(0)),
+            coverage=Count("date"),
+        )
+        conf_total = int(agg["conf_total"] or 0)
+        conf_txs = int(agg["conf_txs"] or 0)
+        avg_conf = round(conf_total / conf_txs, 1) if conf_txs else 0.0
+
+        return {
+            "window": window,
+            "total_multisig_txs": int(agg["proposed"] or 0),
+            "executed_multisig_txs": int(agg["executed"] or 0),
+            "module_txs": int(agg["module"] or 0),
+            "total_value_wei": str(int(agg["native"] or 0)),
+            "avg_confirmations": avg_conf,
+            "avg_confirmations_approximation": "per-tx-day",
+            "coverage_days": int(agg["coverage"] or 0),
+            "computed_at": timezone.now(),
+            "source": "daily_metric",
+        }
+
+    # ── A.6 Safe Segments (Redis-cached) ─────────────────────────────
+
+    def get_safe_segments(self) -> dict:
+        """Read the persisted ``safe_segments`` snapshot.
+
+        Replaces the Redis-cached + 25s-poll read path. See
+        `flickering-honking-wand.md` Part 2.
+        """
+        from safe_transaction_service.analytics.tasks import (
+            compute_safe_segments_task,
+        )
+
+        return self._read_snapshot_or_empty(
+            "safe_segments", EMPTY_SAFE_SEGMENTS_PAYLOAD, compute_safe_segments_task
+        )
+
+    # ── A.7 TVL (canonical source: compute_tvl_task) ─────────────────
+
+    def get_tvl(self) -> dict:
+        """Read the persisted ``tvl`` snapshot (native + ERC20 written
+        atomically by ``compute_tvl_task`` — single ``computed_at``, no
+        drift between sources).
+
+        Replaces the Redis-cached + 25s-poll read path. Cold reads return
+        ``EMPTY_TVL_PAYLOAD`` immediately and fire-and-forget dispatch
+        the refresh; the previous ``safe_statistics`` fallback was
+        removed with that endpoint.
+        """
+        from safe_transaction_service.analytics.tasks import compute_tvl_task
+
+        return self._read_snapshot_or_empty("tvl", EMPTY_TVL_PAYLOAD, compute_tvl_task)
+
+    # ── A.8 Token Volume (direct query — fast enough, not cached) ────
+
+    def get_token_volume(self, window: str) -> dict:
+        days = _parse_window(window)
+        if days is None:
+            days = 30
+
+        payload = self._token_volume_from_rollup(window, days)
+        if payload is not None:
+            return payload
+        logger.info("analytics.rollup.cold_window key=token_volume_%s", window)
+
+        cutoff = timezone.now() - timezone.timedelta(days=days)
+
+        qs = ERC20Transfer.objects.filter(timestamp__gte=cutoff)
+        total_transfers = qs.count()
+        unique_tokens = qs.values("address").distinct().count()
+
+        top_tokens = list(
+            qs.values("address")
+            .annotate(
+                transfer_count=Count("*"),
+                total_value=Sum("value"),
+            )
+            .order_by("-transfer_count")[:20]
+        )
+
+        return {
+            "window": window,
+            "total_erc20_transfers": total_transfers,
+            "unique_tokens": unique_tokens,
+            "top_tokens": [
+                {
+                    "address": t["address"],
+                    "transfer_count": t["transfer_count"],
+                    "total_value": str(t["total_value"] or 0),
+                }
+                for t in top_tokens
+            ],
+            "computed_at": timezone.now(),
+        }
+
+    def _token_volume_from_rollup(self, window: str, days: int) -> dict | None:
+        """Build the same payload from ``analytics_daily_token_volume``.
+
+        Returns None when the rollup is cold for the requested window so
+        the caller can fall through to the live aggregation.
+        """
+        from safe_transaction_service.analytics.models import DailyTokenVolume
+
+        today = timezone.now().date()
+        since = today - timedelta(days=days)
+        rows = list(
+            DailyTokenVolume.objects.filter(date__gte=since)
+            .values("token_address")
+            .annotate(
+                transfer_count=Sum("transfer_count"),
+                total_value=Sum("transfer_value"),
+            )
+            .order_by("-transfer_count")
+        )
+        if not rows:
+            return None
+        total_transfers = sum(int(r["transfer_count"] or 0) for r in rows)
+        unique_tokens = len(rows)
+        top = rows[:20]
+        return {
+            "window": window,
+            "total_erc20_transfers": total_transfers,
+            "unique_tokens": unique_tokens,
+            "top_tokens": [
+                {
+                    "address": t["token_address"],
+                    "transfer_count": int(t["transfer_count"] or 0),
+                    "total_value": str(int(t["total_value"] or 0)),
+                }
+                for t in top
+            ],
+            "computed_at": timezone.now(),
+        }

--- a/safe_transaction_service/analytics/services/db.py
+++ b/safe_transaction_service/analytics/services/db.py
@@ -1,0 +1,107 @@
+"""Database helpers for analytics compute tasks.
+
+`config/settings/base.py` runs every connection with
+`statement_timeout = DB_STATEMENT_TIMEOUT` (50 s by default) as a safety belt
+for the request path. Analytics computes legitimately need minutes — wrap them
+with `relaxed_statement_timeout(...)` to lift the cap only inside the compute
+body. `approx_count_or_exact(...)` swaps a multi-second exact `COUNT(*)` over a
+tens-of-millions-of-rows table for an O(1) read from `pg_class.reltuples`,
+falling back to exact for tiny tables / fresh fixtures so unit tests don't
+depend on ANALYZE having been run.
+"""
+
+import logging
+from contextlib import contextmanager
+
+from django.conf import settings
+from django.db import DatabaseError, ProgrammingError, connection
+
+logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def relaxed_statement_timeout(ms: int = 1_800_000):
+    """Set PG `statement_timeout` to `ms` for the duration of the block.
+
+    Default 30 minutes — high enough to absorb the heaviest analytics
+    aggregates on a multi-million-Safe chain doing month-old backfills
+    (the `_DAILY_ACTIVE_SAFES_SQL` 4-leg UNION + EXISTS lookup against
+    `history_safecontract` legitimately runs 5–10 min per day on BASE
+    once we reach data older than ~30 days; the old 10 min default
+    timed out the Feb/March slice of a 90-day backfill on BASE dev).
+    Still bounded so a stuck statement gets killed eventually instead
+    of pinning a worker forever.
+
+    On exit we restore the value explicitly to `settings.DB_STATEMENT_TIMEOUT`
+    rather than `SET ... = DEFAULT`. Django applies the configured value via
+    the connection startup packet, but `SET DEFAULT` resets to PG's compiled
+    default (no timeout), not to the startup-packet value — so an analytics
+    task running on a pooled connection would otherwise leave the request
+    path's safety belt removed for the next caller.
+
+    If the body throws via a gevent `Timeout` mid-query, the underlying
+    psycopg connection is left in `ACTIVE` state (the protocol never saw
+    the query finish or error). The reset `SET statement_timeout` then
+    raises `OperationalError: another command is already in progress`,
+    which without care would propagate out of `finally` and mask the
+    original exception. Treat that case by dropping the connection so
+    the pool hands out a fresh one (with the startup-packet timeout
+    intact) on the next checkout, and let the original exception
+    propagate.
+    """
+    default_ms = getattr(settings, "DB_STATEMENT_TIMEOUT", 50_000)
+    with connection.cursor() as cursor:
+        cursor.execute(f"SET statement_timeout = {int(ms)}")
+    try:
+        yield
+    finally:
+        try:
+            with connection.cursor() as cursor:
+                cursor.execute(f"SET statement_timeout = {int(default_ms)}")
+        except DatabaseError as exc:
+            # Catch DatabaseError (parent of OperationalError, InternalError,
+            # …) so an aborted-transaction state from a body-side failure
+            # cannot raise on the reset SET and mask the original exception.
+            logger.warning(
+                "relaxed_statement_timeout: failed to reset statement_timeout "
+                "(%s); closing connection to guarantee clean state",
+                exc,
+            )
+            try:
+                connection.close()
+            except Exception:
+                logger.exception(
+                    "relaxed_statement_timeout: failed to close busy connection"
+                )
+
+
+def approx_count_or_exact(model, table_name: str, threshold: int = 1000) -> int:
+    """Return `pg_class.reltuples` for `table_name`, or an exact `COUNT(*)`
+    when the estimate is below `threshold`.
+
+    `reltuples` is updated by VACUUM / ANALYZE, so for fleet-level summary
+    metrics where exact precision is unnecessary it's a constant-time
+    substitute for `COUNT(*)` on tables with tens of millions of rows.
+
+    The threshold fallback exists so unit tests against a freshly created
+    fixture (no ANALYZE has run, reltuples is 0) still get correct numbers
+    — and the cost of `COUNT(*)` on a tiny table is negligible anyway.
+    """
+    # `oid = %s::regclass` resolves the name through PG's search_path and is
+    # unique per table — filtering by `relname` alone can collide across
+    # schemas (multi-tenant partitions, test schemas, …) and return the
+    # wrong row. `regclass` raises if the table doesn't exist, so fall back
+    # to the exact count for not-yet-created tables (e.g. mid-migration).
+    try:
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT reltuples::bigint FROM pg_class WHERE oid = %s::regclass",
+                [table_name],
+            )
+            row = cursor.fetchone()
+    except ProgrammingError:
+        return model.objects.count()
+    approx = int(row[0]) if row and row[0] is not None else 0
+    if approx < threshold:
+        return model.objects.count()
+    return approx

--- a/safe_transaction_service/analytics/tasks.py
+++ b/safe_transaction_service/analytics/tasks.py
@@ -1,43 +1,1684 @@
+import contextlib
 import json
+import logging
+import time
+from datetime import date
 
-from django.db.models import Count, F, Q
+from django.db import connection
+from django.db.models import Count, F, Max, Min, Q
+from django.db.models.functions import Trunc
 from django.utils import timezone
 
 from celery import app
 from dateutil.relativedelta import relativedelta
+from redis.exceptions import LockError
 
+# Force-import `tasks_shards` so its `@app.shared_task` decorators register
+# the sharded tasks (`compute_daily_metric_shard`, `backfill_done`,
+# `compute_native_balance_shard`, `reduce_native_balance_shards`) with the
+# Celery app. Celery's `autodiscover_tasks()` only scans `<app>.tasks` by
+# default — without this import, workers consume the `contracts` queue but
+# see chord-dispatched shards as `unregistered task` and discard them.
+# Side-effect import; intentional. Keep ordering after `LOCK_TIMEOUT` so
+# everything `tasks_shards` depends on is in scope.
+from safe_transaction_service.analytics import tasks_shards  # noqa: F401
+from safe_transaction_service.analytics.models import (
+    AnalyticsSnapshot,
+    DailyActiveOwner,
+    DailyActiveSafe,
+    DailyMetric,
+    DailySafeCreation,
+)
 from safe_transaction_service.analytics.services.analytics_service import (
     AnalyticsService,
 )
-from safe_transaction_service.history.models import MultisigTransaction
+from safe_transaction_service.analytics.services.db import (
+    approx_count_or_exact,
+    relaxed_statement_timeout,
+)
+from safe_transaction_service.history.models import (
+    ERC20Transfer,
+    ERC721Transfer,
+    ModuleTransaction,
+    MultisigConfirmation,
+    MultisigTransaction,
+    SafeContract,
+)
 from safe_transaction_service.utils.celery import task_timeout
 from safe_transaction_service.utils.redis import get_redis
-from safe_transaction_service.utils.tasks import LOCK_TIMEOUT
+from safe_transaction_service.utils.tasks import LOCK_TIMEOUT, only_one_running_task
+
+logger = logging.getLogger(__name__)
 
 
-@app.shared_task()
-@task_timeout(timeout_seconds=LOCK_TIMEOUT)
-def get_transactions_per_safe_app_task():
-    today = timezone.now()
-    last_week = today - relativedelta(days=7)
-    last_month = today - relativedelta(months=1)
-    last_year = today - relativedelta(years=1)
+def _write_snapshot(name: str, payload: dict) -> None:
+    """Upsert one row in `analytics_analyticssnapshot`.
 
-    queryset = (
-        MultisigTransaction.objects.filter(origin__name__isnull=False)
-        .values(name=F("origin__name"), url=F("origin__url"))
-        .annotate(
-            total_tx=Count("origin__name"),
-            tx_last_week=Count("origin__name", filter=Q(created__gt=last_week)),
-            tx_last_month=Count("origin__name", filter=Q(created__gt=last_month)),
-            tx_last_year=Count("origin__name", filter=Q(created__gt=last_year)),
-        )
-        .order_by("-total_tx")
+    Replaces the Redis keys used by current-state metrics
+    (`summary`, `safe_segments`, `tvl`) — see
+    `flickering-honking-wand.md` Part 2. Postgres replaces Redis as the
+    durability layer so a Redis flush / pod restart doesn't reset the
+    cached payload, and the view's old dispatch-and-poll path is gone
+    (a cold read returns the empty payload while fire-and-forget-
+    dispatching the refresh, never blocking the request).
+    """
+    AnalyticsSnapshot.objects.update_or_create(
+        name=name,
+        defaults={"payload": payload, "computed_at": timezone.now()},
     )
 
-    if queryset:
-        redis_key = AnalyticsService.REDIS_TRANSACTIONS_PER_SAFE_APP
-        redis = get_redis()
-        redis.set(redis_key, json.dumps(list(queryset)))
-        return True
-    return False
+
+def _iter_safe_addresses_keyset(batch_size: int = 5000):
+    """Yield batches of ``SafeContract.address`` using keyset pagination.
+
+    ``SafeContract.address`` is the bytea PK (``EthereumAddressBinaryField``),
+    so ``address__gt=last`` produces an indexed range scan and each fetch
+    stays O(log N + batch_size). The old ``queryset[offset:offset+batch_size]``
+    form compiled to ``OFFSET/LIMIT``, which on a multi-million-Safe chain
+    forced PG to scan and discard every preceding row on every batch —
+    quadratic over the loop, multi-minute per call once the offset crossed
+    ~500k.
+    """
+    base_qs = SafeContract.objects.values_list("address", flat=True).order_by("pk")
+    last: str | None = None
+    while True:
+        qs = base_qs.filter(address__gt=last) if last is not None else base_qs
+        chunk = list(qs[:batch_size])
+        if not chunk:
+            return
+        yield chunk
+        last = chunk[-1]
+
+
+BALANCE_BATCH_SQL = """
+    SELECT
+        COALESCE(SUM(CASE WHEN balance > 0 THEN balance ELSE 0 END), 0),
+        COUNT(*) FILTER (WHERE balance > 0)
+    FROM (
+        SELECT
+            addr,
+            SUM(CASE WHEN direction = 1 THEN value ELSE -value END) AS balance
+        FROM (
+            SELECT it."to" AS addr, it.value, 1 AS direction
+            FROM history_internaltx it
+            WHERE it."to" = ANY(%s)
+              AND it.call_type = 0 AND it.value > 0 AND it.error IS NULL
+            UNION ALL
+            SELECT it."_from" AS addr, it.value, -1 AS direction
+            FROM history_internaltx it
+            WHERE it."_from" = ANY(%s)
+              AND it.call_type = 0 AND it.value > 0 AND it.error IS NULL
+        ) transfers
+        GROUP BY addr
+    ) safe_balances
+"""
+
+
+def _calculate_native_balances_from_db_sequential() -> tuple[int, int]:
+    """
+    Sequential reference implementation kept as a fallback / for tests.
+    Calculate native token balances using DB aggregation on InternalTx,
+    processed in batches to stay within the 50-second statement timeout.
+
+    The default entry point ``_calculate_native_balances_from_db`` now
+    fans this work out across 16 hex-prefix shards via Celery (see
+    ``tasks_shards.dispatch_native_balance_shards``). On a fresh deploy
+    or when called from a worker that *is* the consumer of its own
+    shards (single-worker chains), the chord deadlocks — so callers can
+    opt into this sequential path by passing ``parallel=False``.
+    """
+    start_time = time.time()
+    batch_size = 5000
+    total_balance_wei = 0
+    total_safes_with_balance = 0
+    processed = 0
+
+    total_safes = SafeContract.objects.count()
+    logger.info(
+        "native_balance.sequential: starting total_safes=%d batch_size=%d",
+        total_safes,
+        batch_size,
+    )
+
+    batch_number = 0
+
+    # Open the relaxed timeout once for the whole batch loop. Each batch
+    # already takes seconds on staging (batch 14 at ~8 s) and the default
+    # 50 s request-path timeout was silently dropping batches on planner
+    # flips at scale. Per-batch try/except still isolates individual
+    # failures from the rest of the run.
+    with relaxed_statement_timeout():
+        for addresses in _iter_safe_addresses_keyset(batch_size):
+            batch_number += 1
+            processed += len(addresses)
+            batch_start = time.time()
+
+            # Convert checksummed address strings to bytes for bytea comparison
+            address_bytes = [bytes.fromhex(addr[2:]) for addr in addresses]
+
+            try:
+                with connection.cursor() as cursor:
+                    cursor.execute(BALANCE_BATCH_SQL, [address_bytes, address_bytes])
+                    row = cursor.fetchone()
+
+                batch_balance = int(row[0]) if row[0] else 0
+                batch_count = int(row[1]) if row[1] else 0
+                total_balance_wei += batch_balance
+                total_safes_with_balance += batch_count
+
+                logger.info(
+                    "native_balance.sequential: batch %d done %d/%d in %.2fs "
+                    "running_total_wei=%d running_safes_with_balance=%d",
+                    batch_number,
+                    processed,
+                    total_safes,
+                    time.time() - batch_start,
+                    total_balance_wei,
+                    total_safes_with_balance,
+                )
+            except Exception:
+                logger.exception(
+                    "native_balance.sequential: batch %d failed after %.2fs "
+                    "addresses[0]=%s addresses[-1]=%s",
+                    batch_number,
+                    time.time() - batch_start,
+                    addresses[0] if addresses else "N/A",
+                    addresses[-1] if addresses else "N/A",
+                )
+                # Continue with next batch — partial results still useful
+
+    elapsed = time.time() - start_time
+    logger.info(
+        "native_balance.sequential: completed in %.2fs total_wei=%d "
+        "safes_with_balance=%d/%d",
+        elapsed,
+        total_balance_wei,
+        total_safes_with_balance,
+        processed,
+    )
+    return total_balance_wei, total_safes_with_balance
+
+
+def _calculate_native_balances_from_db(parallel: bool = False) -> tuple[int, int]:
+    """In-process native-balance aggregation.
+
+    The chord path that used to live here has moved into
+    ``compute_tvl_task`` (which now dispatches the 16-shard chord directly
+    via ``dispatch_tvl_chord``) — the blocking ``.get()`` it required was
+    the cause of the silent TVL hangs on chains with gevent workers + a
+    Redis result backend. The ``parallel`` kwarg is kept for source
+    compatibility but ignored; this entry point now always runs the
+    sequential implementation, which is what tests and ad-hoc invocations
+    actually want.
+    """
+    return _calculate_native_balances_from_db_sequential()
+
+
+@app.shared_task(bind=True)
+@task_timeout(timeout_seconds=LOCK_TIMEOUT * 2)
+def get_transactions_per_safe_app_task(self):
+    """Aggregate multisig txs grouped by origin name + URL and cache to Redis.
+
+    Dual-write: keeps the legacy Redis payload fresh as a cold-rollup
+    fallback for the read path, *and* populates ``analytics_dailysafeapptx``
+    for every distinct day that holds origin-bearing multisig activity so
+    the rollup table is hydrated without a separate backfill pass.
+
+    Guarded by ``only_one_running_task(self)`` so a manual ``.delay()`` while
+    the Sunday cron is still running does not race the same UPSERT.
+    """
+    with contextlib.suppress(LockError):
+        with only_one_running_task(self):
+            started = time.time()
+            logger.info("get_transactions_per_safe_app_task: starting")
+            today = timezone.now()
+            last_week = today - relativedelta(days=7)
+            last_month = today - relativedelta(months=1)
+            last_year = today - relativedelta(years=1)
+
+            queryset = (
+                MultisigTransaction.objects.filter(origin__name__isnull=False)
+                .values(name=F("origin__name"), url=F("origin__url"))
+                .annotate(
+                    total_tx=Count("origin__name"),
+                    tx_last_week=Count("origin__name", filter=Q(created__gt=last_week)),
+                    tx_last_month=Count(
+                        "origin__name", filter=Q(created__gt=last_month)
+                    ),
+                    tx_last_year=Count("origin__name", filter=Q(created__gt=last_year)),
+                )
+                .order_by("-total_tx")
+            )
+
+            wrote_redis = False
+            redis_rows = 0
+            if queryset:
+                redis_key = AnalyticsService.REDIS_TRANSACTIONS_PER_SAFE_APP
+                redis_payload = list(queryset)
+                redis_rows = len(redis_payload)
+                redis = get_redis()
+                redis.set(redis_key, json.dumps(redis_payload))
+                wrote_redis = True
+
+            # Dual-write to the rollup. One SQL pass groups every executed
+            # multisig tx by (block.date, origin.name); ON CONFLICT keeps it
+            # idempotent.
+            rollup_rows = 0
+            try:
+                with relaxed_statement_timeout(), connection.cursor() as cursor:
+                    cursor.execute(
+                        """
+                        INSERT INTO analytics_dailysafeapptx
+                            (date, origin_name, origin_url, tx_count)
+                        SELECT date, origin_name, origin_url, tx_count FROM (
+                            SELECT
+                                (eb.timestamp AT TIME ZONE 'UTC')::date AS date,
+                                COALESCE(mt.origin->>'name', '') AS origin_name,
+                                COALESCE(MAX(mt.origin->>'url'), '') AS origin_url,
+                                COUNT(*) AS tx_count
+                            FROM history_multisigtransaction mt
+                            JOIN history_ethereumtx etx
+                                ON mt.ethereum_tx_id = etx.tx_hash
+                            JOIN history_ethereumblock eb
+                                ON etx.block_id = eb.number
+                            WHERE mt.origin->>'name' IS NOT NULL
+                              AND mt.origin->>'name' <> ''
+                            GROUP BY date, origin_name
+                        ) src
+                        ON CONFLICT (date, origin_name) DO UPDATE SET
+                            origin_url = EXCLUDED.origin_url,
+                            tx_count   = EXCLUDED.tx_count
+                        """
+                    )
+                    rollup_rows = cursor.rowcount
+            except Exception:
+                logger.exception(
+                    "get_transactions_per_safe_app_task: rollup dual-write failed"
+                )
+
+            logger.info(
+                "get_transactions_per_safe_app_task: completed in %.2fs "
+                "redis_rows=%d rollup_rows=%d wrote_redis=%s",
+                time.time() - started,
+                redis_rows,
+                rollup_rows,
+                wrote_redis,
+            )
+            return wrote_redis
+
+
+@app.shared_task(bind=True)
+@task_timeout(timeout_seconds=LOCK_TIMEOUT * 2)
+def compute_summary_task(self):
+    """Write the ``summary`` snapshot consumed by ``GET /v2/analytics/summary/``.
+
+    Cheap fleet-level counts only: ``total_safes`` via ``SafeContract.count()``
+    plus four ``approx_count_or_exact`` reads off ``history_*`` (constant-time
+    on big tables; falls back to exact ``COUNT(*)`` for fixtures), and
+    first/last creation timestamps via ``Min/Max`` on the indexed
+    ``SafeContract.created`` column. No joins, no scans through
+    ``MultisigConfirmation``, no native-balance work — that path lives in
+    ``compute_tvl_task``.
+
+    Replaces the previous ``get_safe_statistics_task``, which produced both
+    the ``safe_statistics`` and ``summary`` snapshots. ``/safe-statistics/``
+    is gone (see plan ``robust-wandering-spark.md``); the owner-iteration
+    and native-balance phases that endpoint required were removed with it.
+    """
+    with contextlib.suppress(LockError):
+        with only_one_running_task(self):
+            started = time.time()
+            logger.info("compute_summary_task: starting")
+            try:
+                total_safes = SafeContract.objects.count()
+
+                with relaxed_statement_timeout():
+                    dates = SafeContract.objects.aggregate(
+                        first=Min("created"),
+                        last=Max("created"),
+                    )
+                    summary = {
+                        "total_safes": total_safes,
+                        "total_multisig_txs": approx_count_or_exact(
+                            MultisigTransaction, "history_multisigtransaction"
+                        ),
+                        "total_module_txs": approx_count_or_exact(
+                            ModuleTransaction, "history_moduletransaction"
+                        ),
+                        "total_erc20_transfers": approx_count_or_exact(
+                            ERC20Transfer, "history_erc20transfer"
+                        ),
+                        "total_erc721_transfers": approx_count_or_exact(
+                            ERC721Transfer, "history_erc721transfer"
+                        ),
+                        "first_safe_created": (
+                            dates["first"].isoformat() if dates["first"] else None
+                        ),
+                        "last_safe_created": (
+                            dates["last"].isoformat() if dates["last"] else None
+                        ),
+                        "computed_at": timezone.now().isoformat(),
+                    }
+                    _write_snapshot("summary", summary)
+
+                logger.info(
+                    "compute_summary_task: completed in %.2fs total_safes=%d",
+                    time.time() - started,
+                    total_safes,
+                )
+                return True
+            except Exception:
+                logger.exception(
+                    "compute_summary_task: failed after %.2fs",
+                    time.time() - started,
+                )
+                return False
+
+
+# Per-anchor EXISTS probe: for each Safe address in the batch, ask the
+# planner to stop on the first matching transfer row using the
+# `(_from, timestamp)` / `(to, timestamp)` covering indexes. The old
+# DISTINCT-over-UNION form had to read every transfer row in the window
+# for any active Safe; this form is O(addresses_in_batch * 2 index probes)
+# regardless of how many transfers each Safe has.
+_ERC20_ACTIVE_BATCH_SQL = """
+    SELECT a.addr
+    FROM unnest(%s::bytea[]) AS a(addr)
+    WHERE EXISTS (
+        SELECT 1 FROM history_erc20transfer
+        WHERE "_from" = a.addr AND timestamp >= %s
+        LIMIT 1
+    ) OR EXISTS (
+        SELECT 1 FROM history_erc20transfer
+        WHERE "to" = a.addr AND timestamp >= %s
+        LIMIT 1
+    )
+"""
+
+# Closed-interval variant for per-day DAU computations (C7).
+#
+# Scans only the day's transfers (bounded by the `timestamp` index range)
+# and joins back to `history_safecontract` — one query, two index range
+# scans, zero per-Safe probes. The old form looped over all Safes in
+# batches of 5000 and ran a paired EXISTS per Safe, which on a 1.5M-Safe
+# chain meant ~2M btree probes and ~200 round-trips for what is now a
+# single statement.
+_ERC20_ACTIVE_BETWEEN_JOIN_SQL = """
+    SELECT sc.address
+    FROM history_safecontract sc
+    JOIN (
+        SELECT "_from" AS address FROM history_erc20transfer
+        WHERE timestamp >= %s AND timestamp < %s
+        UNION
+        SELECT "to" AS address FROM history_erc20transfer
+        WHERE timestamp >= %s AND timestamp < %s
+    ) t ON sc.address = t.address
+"""
+
+
+def _normalize_addr(value) -> str:
+    """Coerce a value to a lowercase `0x...` hex string regardless of whether
+    it came back as a checksummed string (Django ORM) or raw bytea
+    (`cursor.execute`)."""
+    if isinstance(value, memoryview):
+        value = bytes(value)
+    if isinstance(value, (bytes, bytearray)):
+        return "0x" + value.hex()
+    return value.lower() if isinstance(value, str) else value
+
+
+def _erc20_active_safe_addrs(cutoff, batch_size: int = 5000) -> set[str]:
+    """Return the set of Safe addresses that appear as `_from` or `to` of
+    an ERC20 transfer at or after `cutoff`.
+
+    Reverses the direction of the old
+    `ERC20Transfer.filter(_from__in=SafeContract)` query, which forced the
+    planner to scan every transfer in the window and probe SafeContract per
+    row. Here we anchor on batches of 5 000 SafeContract addresses and let
+    the `(_from, timestamp)` / `(to, timestamp)` covering indexes do the
+    lookup — the same batched-probe pattern that
+    `_calculate_native_balances_from_db` uses to stay under the per-statement
+    budget on multi-hundred-thousand-Safe chains.
+    """
+    seen: set[str] = set()
+    for addresses in _iter_safe_addresses_keyset(batch_size):
+        addr_bytes = [bytes.fromhex(a[2:]) for a in addresses]
+        with connection.cursor() as cursor:
+            cursor.execute(_ERC20_ACTIVE_BATCH_SQL, [addr_bytes, cutoff, cutoff])
+            for row in cursor:
+                seen.add(_normalize_addr(row[0]))
+    return seen
+
+
+def _safes_active_in_window(cutoff) -> int:
+    """Distinct count of Safes that produced multisig/module activity or
+    ERC20 movement at or after `cutoff`."""
+    active: set[str] = set()
+
+    # Multisig / module legs filter on block.timestamp / internal_tx.timestamp.
+    # Both are bounded by the window, not by the transfers table size, so
+    # they finish in tens of ms even on chains with ~1M txs.
+    active.update(
+        _normalize_addr(a)
+        for a in MultisigTransaction.objects.filter(
+            ethereum_tx__block__timestamp__gte=cutoff
+        )
+        .values_list("safe", flat=True)
+        .distinct()
+    )
+    active.update(
+        _normalize_addr(a)
+        for a in ModuleTransaction.objects.filter(internal_tx__timestamp__gte=cutoff)
+        .values_list("safe", flat=True)
+        .distinct()
+    )
+    # ERC20 leg: batched index probe (see `_erc20_active_safe_addrs`).
+    active.update(_erc20_active_safe_addrs(cutoff))
+    return len(active)
+
+
+@app.shared_task(bind=True)
+@task_timeout(timeout_seconds=LOCK_TIMEOUT * 4)
+def compute_active_safes_task(self):
+    """Compute active Safes for 7d / 30d / 90d windows and cache in Redis.
+
+    Each window is computed independently inside its own try/except so a
+    failure on the heaviest window (90 d on a chain with tens of millions
+    of transfers) doesn't strand the 7 d / 30 d results.
+    """
+    with contextlib.suppress(LockError):
+        with only_one_running_task(self):
+            started = time.time()
+            logger.info("compute_active_safes_task: starting windows=7d,30d,90d")
+            redis = get_redis()
+            now = timezone.now()
+
+            ok_windows: list[str] = []
+            counts: dict[str, int] = {}
+            for window_str, days in [("7d", 7), ("30d", 30), ("90d", 90)]:
+                window_started = time.time()
+                cutoff = now - timezone.timedelta(days=days)
+                try:
+                    with relaxed_statement_timeout():
+                        count = _safes_active_in_window(cutoff)
+                except Exception:
+                    logger.exception(
+                        "compute_active_safes_task: window %s failed after %.2fs",
+                        window_str,
+                        time.time() - window_started,
+                    )
+                    continue
+                result = {
+                    "window": window_str,
+                    "active_safes": count,
+                    "computed_at": now.isoformat(),
+                }
+                redis.set(
+                    AnalyticsService.REDIS_ACTIVE_SAFES_PREFIX + window_str,
+                    json.dumps(result),
+                )
+                ok_windows.append(window_str)
+                counts[window_str] = count
+                logger.info(
+                    "compute_active_safes_task: window %s took %.2fs active_safes=%d",
+                    window_str,
+                    time.time() - window_started,
+                    count,
+                )
+
+            logger.info(
+                "compute_active_safes_task: completed in %.2fs ok_windows=%s counts=%s",
+                time.time() - started,
+                ok_windows,
+                counts,
+            )
+            return bool(ok_windows)
+
+
+_ACTIVE_OWNERS_FALLBACK_SQL = """
+    SELECT COUNT(DISTINCT mc.owner)
+    FROM history_ethereumtx et
+    JOIN history_multisigtransaction mt
+        ON mt.ethereum_tx_id = et.tx_hash
+    JOIN history_multisigconfirmation mc
+        ON mc.multisig_transaction_id = mt.safe_tx_hash
+    WHERE et.block_id >= (
+        SELECT MIN(number)
+        FROM history_ethereumblock
+        WHERE timestamp >= %s
+    )
+"""
+# The 4-table join shape (eb ⋈ et ⋈ mt ⋈ mc) is collapsed by exploiting
+# the fact that ``EthereumBlock.number`` is strictly monotonic on a chain:
+# resolving the cutoff to a single ``MIN(number)`` via the
+# ``history_ethereumblock(timestamp)`` btree index (one row, sub-ms) lets
+# us range-scan ``history_ethereumtx`` directly on its FK-indexed
+# ``block_id`` column. PG can then nested-loop et → mt → mc through their
+# FK indexes, with ``DISTINCT owner`` folded into a hash aggregate. We
+# trade the upper-bound predicate on ``eb.timestamp`` for a chain-block
+# count, which is fine: timestamps are roughly monotonic with number and
+# the worst-case inversion on EVM L2s is ~tens of seconds — irrelevant
+# for 7/30/90 d aggregates.
+
+
+def _active_owners_in_window(cutoff, batch_size: int = 5000) -> int:
+    """Distinct count of owners whose signed multisig tx executed on-chain
+    in `[cutoff, now]`.
+
+    Fast path: aggregate over the per-day ``DailyActiveOwner`` rollup
+    populated by ``compute_daily_metrics_task`` — a single
+    ``COUNT(DISTINCT owner_address)`` over the date range, sub-100 ms
+    regardless of ``history_*`` size. Matches the semantic of the rollup
+    populator (owners with at least one confirmation on a tx executed
+    that UTC day).
+
+    Cold-window fallback: if the rollup has no rows covering the window
+    (fresh instance / pre-backfill / a long gap since the last daily
+    run), drop the whole aggregation to PG. See
+    ``_ACTIVE_OWNERS_FALLBACK_SQL``: a single statement, 3-table
+    inner join (et ⋈ mt ⋈ mc) gated by a scalar
+    ``MIN(history_ethereumblock.number)`` subquery — collapses the
+    fourth (block) table to a one-row index probe by exploiting block
+    monotonicity, then range-scans ``history_ethereumtx`` on its
+    FK-indexed ``block_id`` and nested-loops outward through the
+    confirmation FK index. The previous Python form materialised every
+    executed ``safe_tx_hash`` in window into a list (later: a streaming
+    iterator) and probed ``MultisigConfirmation`` in 5 k-id batches,
+    deduping owners in Python — on BASE (1.5 M Safes, 90 d window) that
+    pinned a gevent worker past its task timeout and poisoned the
+    connection. ``batch_size`` is retained on the signature for callers
+    / tests that still pass it, but is unused on the SQL path. Emits
+    ``analytics.rollup.cold_window`` when the fallback fires.
+    """
+    cutoff_date = cutoff.date() if hasattr(cutoff, "date") else cutoff
+    rollup_qs = DailyActiveOwner.objects.filter(date__gte=cutoff_date)
+    if rollup_qs.exists():
+        return rollup_qs.values("owner_address").distinct().count()
+
+    logger.info(
+        "analytics.rollup.cold_window key=active_owners cutoff=%s",
+        cutoff_date,
+    )
+    with connection.cursor() as cursor:
+        cursor.execute(_ACTIVE_OWNERS_FALLBACK_SQL, [cutoff])
+        row = cursor.fetchone()
+    return int(row[0]) if row and row[0] is not None else 0
+
+
+@app.shared_task(bind=True)
+@task_timeout(timeout_seconds=LOCK_TIMEOUT * 4)
+def compute_active_owners_task(self):
+    """Compute active owners for 7d / 30d / 90d windows and cache in Redis.
+
+    Per-window try/except so the smaller windows still land if the largest
+    one overruns. `_active_owners_in_window` runs the heavy join in batched
+    form under a relaxed statement timeout.
+    """
+    with contextlib.suppress(LockError):
+        with only_one_running_task(self):
+            started = time.time()
+            logger.info("compute_active_owners_task: starting windows=7d,30d,90d")
+            redis = get_redis()
+            now = timezone.now()
+
+            ok_windows: list[str] = []
+            counts: dict[str, int] = {}
+            for window_str, days in [("7d", 7), ("30d", 30), ("90d", 90)]:
+                window_started = time.time()
+                cutoff = now - timezone.timedelta(days=days)
+                try:
+                    with relaxed_statement_timeout():
+                        count = _active_owners_in_window(cutoff)
+                except Exception:
+                    logger.exception(
+                        "compute_active_owners_task: window %s failed after %.2fs",
+                        window_str,
+                        time.time() - window_started,
+                    )
+                    continue
+                result = {
+                    "window": window_str,
+                    "active_owners": count,
+                    "computed_at": now.isoformat(),
+                }
+                redis.set(
+                    AnalyticsService.REDIS_ACTIVE_OWNERS_PREFIX + window_str,
+                    json.dumps(result),
+                )
+                ok_windows.append(window_str)
+                counts[window_str] = count
+                logger.info(
+                    "compute_active_owners_task: window %s took %.2fs active_owners=%d",
+                    window_str,
+                    time.time() - window_started,
+                    count,
+                )
+
+            logger.info(
+                "compute_active_owners_task: completed in %.2fs ok_windows=%s counts=%s",
+                time.time() - started,
+                ok_windows,
+                counts,
+            )
+            return bool(ok_windows)
+
+
+_SAFE_SEGMENTS_SQL = """
+    WITH latest AS (
+        SELECT DISTINCT ON (address)
+            address, threshold, owners, enabled_modules
+        FROM history_safestatus
+        ORDER BY address, nonce DESC, internal_tx_id DESC
+    )
+    SELECT
+        COUNT(*) FILTER (WHERE COALESCE(array_length(owners, 1), 0) <= 1) AS personal,
+        COUNT(*) FILTER (WHERE array_length(owners, 1) BETWEEN 2 AND 5)   AS team,
+        COUNT(*) FILTER (WHERE COALESCE(array_length(owners, 1), 0) > 5)  AS enterprise,
+        COUNT(*) FILTER (WHERE enabled_modules IS NOT NULL
+                              AND array_length(enabled_modules, 1) > 0)   AS with_modules,
+        COUNT(*)                                                          AS total,
+        AVG(threshold)::float                                             AS avg_threshold,
+        AVG(COALESCE(array_length(owners, 1), 0))::float                  AS avg_owners
+    FROM latest
+"""
+
+
+@app.shared_task(bind=True)
+@task_timeout(timeout_seconds=LOCK_TIMEOUT * 4)
+def compute_safe_segments_task(self):
+    """Compute Safe segments from latest SafeStatus per address, cache in Redis.
+
+    The previous Python iterator over `SafeStatus.last_for_every_address()`
+    took ~10 min on a 250 k-Safe fleet because the DISTINCT-ON QuerySet
+    streamed every latest-status row through the ORM. The aggregate is
+    pushed entirely into Postgres so a 632 s task collapses to seconds —
+    the `(address, -nonce)` index on `history_safestatus` carries the
+    DISTINCT-ON.
+    """
+    with contextlib.suppress(LockError):
+        with only_one_running_task(self):
+            started = time.time()
+            logger.info("compute_safe_segments_task: starting")
+            now = timezone.now()
+
+            with relaxed_statement_timeout():
+                with connection.cursor() as cursor:
+                    cursor.execute(_SAFE_SEGMENTS_SQL)
+                    (
+                        personal,
+                        team,
+                        enterprise,
+                        with_modules,
+                        count,
+                        avg_threshold,
+                        avg_owners,
+                    ) = cursor.fetchone()
+
+            result = {
+                "personal": int(personal or 0),
+                "team": int(team or 0),
+                "enterprise": int(enterprise or 0),
+                "with_modules": int(with_modules or 0),
+                "avg_threshold": round(float(avg_threshold or 0.0), 1),
+                "avg_owners": round(float(avg_owners or 0.0), 1),
+                "computed_at": now.isoformat(),
+            }
+            _write_snapshot("safe_segments", result)
+            logger.info(
+                "compute_safe_segments_task: completed in %.2fs total=%d "
+                "personal=%d team=%d enterprise=%d with_modules=%d",
+                time.time() - started,
+                int(count or 0),
+                int(personal or 0),
+                int(team or 0),
+                int(enterprise or 0),
+                int(with_modules or 0),
+            )
+            return True
+
+
+@app.shared_task(bind=True)
+@task_timeout(timeout_seconds=LOCK_TIMEOUT)
+def compute_tvl_task(self):
+    """Fire-and-forget driver for the TVL pipeline.
+
+    Writes a phase-1 placeholder snapshot only if none exists yet, then
+    dispatches the chord ``(16 native shards) → reduce → finalize_tvl_snapshot``
+    on the ``contracts`` queue and returns immediately. The final
+    snapshot is written by ``finalize_tvl_snapshot`` when the chord
+    resolves — see ``analytics.tasks_shards.finalize_tvl_snapshot``.
+
+    The previous shape blocked on ``.get()`` waiting for the chord, which
+    hung indefinitely on gevent workers + Redis result backend. The new
+    shape is event-driven: success of the heavy aggregation is observable
+    via the snapshot's ``computed_at`` advancing past the placeholder.
+    """
+    with contextlib.suppress(LockError):
+        with only_one_running_task(self):
+            from safe_transaction_service.analytics.tasks_shards import (
+                dispatch_tvl_chord,
+            )
+
+            started = time.time()
+            logger.info("compute_tvl_task: starting")
+
+            # Phase 1 — only seed the placeholder when nothing is there
+            # yet. Overwriting a previously-good snapshot would zero out
+            # the endpoint for the entire chord duration on every run.
+            if not AnalyticsSnapshot.objects.filter(name="tvl").exists():
+                placeholder = {
+                    "total_safes_with_balance": 0,
+                    "native_balance_wei": "0",
+                    "erc20_token_count": 0,
+                    "top_tokens": [],
+                    # 0/0 marks this as a "never-computed" placeholder so
+                    # consumers can distinguish it from a real partial run
+                    # written by `finalize_tvl_snapshot`.
+                    "partial_shards": 0,
+                    "total_shards": 0,
+                    "computed_at": timezone.now().isoformat(),
+                }
+                _write_snapshot("tvl", placeholder)
+                logger.info("compute_tvl_task: phase1 placeholder snapshot written")
+
+            # Phase 2 — fire-and-forget. The chord callback
+            # (`finalize_tvl_snapshot`) does the ERC20 aggregation and
+            # writes the real snapshot when shards + reduce resolve.
+            dispatch_tvl_chord()
+            logger.info(
+                "compute_tvl_task: chord dispatched in %.2fs",
+                time.time() - started,
+            )
+            return True
+
+
+@app.shared_task(bind=True)
+@task_timeout(timeout_seconds=LOCK_TIMEOUT * 2)
+def compute_safe_creations_task(self):
+    """
+    Compute Safe creations day-grain series, cache in Redis.
+
+    Post-rollups: reads the series directly from
+    ``analytics_dailysafecreation`` when the table is populated (constant-
+    time scan of a ~1k-row table on the oldest chains). Falls back to the
+    live ``SafeContract → EthereumTx → EthereumBlock`` join when the
+    rollup is cold (fresh deploy / mid-backfill) and on success backfills
+    the rollup so subsequent runs are instant.
+
+    Only the day-grain series is cached. Week and month buckets are
+    derived from it in-memory at request time.
+
+    Guarded by ``only_one_running_task(self)`` so a manual ``.delay()`` while
+    the daily cron is still running does not race the rollup upsert loop.
+    """
+    with contextlib.suppress(LockError):
+        with only_one_running_task(self):
+            started = time.time()
+            logger.info("compute_safe_creations_task: starting")
+            rollup_rows = list(DailySafeCreation.objects.order_by("date").all())
+            if rollup_rows:
+                series = [
+                    {"period": r.date.isoformat(), "count": r.count}
+                    for r in rollup_rows
+                ]
+                payload = {
+                    "series": series,
+                    "computed_at": timezone.now().isoformat(),
+                }
+                get_redis().set(
+                    AnalyticsService.REDIS_SAFE_CREATIONS, json.dumps(payload)
+                )
+                logger.info(
+                    "compute_safe_creations_task: completed in %.2fs "
+                    "source=rollup buckets=%d",
+                    time.time() - started,
+                    len(series),
+                )
+                return True
+
+            logger.info(
+                "analytics.rollup.cold_window key=safe_creations "
+                "falling back to live aggregation and backfilling"
+            )
+            with relaxed_statement_timeout():
+                rows = (
+                    SafeContract.objects.annotate(
+                        period=Trunc("ethereum_tx__block__timestamp", "day")
+                    )
+                    .values("period")
+                    .annotate(count=Count("address"))
+                    .order_by("period")
+                )
+                materialised = [
+                    {"period": row["period"].date().isoformat(), "count": row["count"]}
+                    for row in rows
+                    if row["period"] is not None
+                ]
+                # Backfill rollup so future calls hit the fast path.
+                # Idempotent via update_or_create on the primary-key date
+                # column.
+                for row in materialised:
+                    DailySafeCreation.objects.update_or_create(
+                        date=date.fromisoformat(row["period"]),
+                        defaults={"count": row["count"]},
+                    )
+            payload = {
+                "series": materialised,
+                "computed_at": timezone.now().isoformat(),
+                "source": "live",
+            }
+            get_redis().set(AnalyticsService.REDIS_SAFE_CREATIONS, json.dumps(payload))
+            logger.info(
+                "compute_safe_creations_task: completed in %.2fs "
+                "source=live+backfill buckets=%d",
+                time.time() - started,
+                len(materialised),
+            )
+            return True
+
+
+# ───────────────────────── C7: DailyMetric pipeline ─────────────────────────
+#
+# `compute_daily_metrics_task` runs incrementally (default: yesterday only),
+# upserts one row per day in `analytics_dailymetric`, and refreshes the
+# rolling-window distinct active_* Redis caches in the same task run so the
+# read-path semantics stay unchanged. The same `_upsert_daily_metric` helper
+# is reused by the `backfill_daily_metrics` management command for one-shot
+# history loads on a fresh chain.
+
+
+def _erc20_active_safe_addrs_between(start, end) -> set[str]:
+    """Set of Safe addresses with an ERC20 transfer in `[start, end)`.
+
+    Single JOIN: index-range-scan the day's transfers and join back to
+    `history_safecontract`. Replaces the prior per-Safe EXISTS batch loop
+    that issued ~200 round-trips and ~2M btree probes on a 1.5M-Safe
+    chain.
+    """
+    with connection.cursor() as cursor:
+        cursor.execute(_ERC20_ACTIVE_BETWEEN_JOIN_SQL, [start, end, start, end])
+        return {_normalize_addr(row[0]) for row in cursor}
+
+
+def _safes_active_between(start, end) -> int:
+    """Closed-interval distinct count of active Safes in `[start, end)`.
+    Used by C7 per-day DAU rows; the open-ended form (`_safes_active_in_window`)
+    is still used by the standalone active_* tasks and the rolling-window
+    refresh in `_refresh_active_window_caches`.
+
+    Thin wrapper around `_safes_active_between_set` — the rollup populator
+    needs the membership, the DAU column only needs the cardinality.
+    """
+    # Forward declaration: the set helper is defined below `_upsert_daily_metric`
+    # so it can call into the rollup-populator helpers that themselves use
+    # `_erc20_active_safe_addrs_between` (also defined here). The same function
+    # is called from both directions; Python resolves at call time so order is
+    # fine — but if you reorganize, keep both in this module.
+    return len(_safes_active_between_set(start, end))
+
+
+def _active_owners_between(start, end, batch_size: int = 5000) -> int:
+    """Closed-interval distinct count of confirming owners in `[start, end)`."""
+    executed_tx_ids = list(
+        MultisigTransaction.objects.filter(
+            ethereum_tx__block__timestamp__gte=start,
+            ethereum_tx__block__timestamp__lt=end,
+        ).values_list("safe_tx_hash", flat=True)
+    )
+    seen: set[str] = set()
+    for i in range(0, len(executed_tx_ids), batch_size):
+        chunk = executed_tx_ids[i : i + batch_size]
+        seen.update(
+            _normalize_addr(o)
+            for o in MultisigConfirmation.objects.filter(
+                multisig_transaction_id__in=chunk
+            )
+            .values_list("owner", flat=True)
+            .distinct()
+        )
+    return len(seen)
+
+
+_METRIC_CORE_NEW_SAFES_SQL = """
+SELECT COUNT(*)
+FROM history_safecontract sc
+JOIN history_ethereumtx etx ON sc.ethereum_tx_id = etx.tx_hash
+WHERE etx.block_id >= %s AND etx.block_id < %s
+"""
+
+# Combined count + native-wei sum in one round-trip. The legacy ORM form
+# evaluated `multisig_executed_qs.count()` and
+# `multisig_executed_qs.aggregate(Sum)` as two separate queries — same
+# join shape, executed twice. One SQL with both aggregates halves the
+# wall-clock for this step. The cast to `text` (then to Python int in
+# the caller) keeps the value precise for the uint256 sum without
+# relying on Django's implicit DecimalField precision.
+_METRIC_CORE_MULTISIG_COUNT_SUM_SQL = """
+SELECT
+    COUNT(*) AS tx_count,
+    COALESCE(SUM(mt.value), 0)::text AS native_wei
+FROM history_multisigtransaction mt
+JOIN history_ethereumtx etx ON mt.ethereum_tx_id = etx.tx_hash
+WHERE etx.block_id >= %s AND etx.block_id < %s
+"""
+
+
+def _compute_daily_metric_core(day_start, day_end) -> DailyMetric:
+    """Upsert the `DailyMetric` row for `[day_start, day_end)`.
+
+    Carved out of `_upsert_daily_metric` so the per-day write path can be
+    sharded across Celery workers (one task per day) without dragging the
+    four rollup populators along on every retry path.
+
+    Each of the three timestamp-bounded aggregates (`new_safes`,
+    `multisig_txs_executed`, `native_value_wei`) is anchored on
+    `etx.block_id` (FK-indexed) after a block-window pre-resolve. The
+    prior ORM form (`ethereum_tx__block__timestamp__gte=…`) emitted a
+    3-table join with WHERE on `eb.timestamp`, which on busy chains
+    produced a plan that did not prune `etx` early — the three queries
+    together took ~40 min/day in the original implementation. The
+    block-window form puts each in the seconds range.
+
+    `multisig_txs_executed` and `native_value_wei` share the same join
+    shape; combined into a single SQL with two aggregates to halve the
+    round-trip.
+
+    `module_txs` keeps the simple 2-table ORM filter on
+    `internal_tx.timestamp` (directly btree-indexed); `erc20_transfers`
+    keeps the 1-table count on its own timestamp index. Neither is the
+    bottleneck.
+    """
+    start_block, end_block = _resolve_block_window(day_start, day_end)
+    if start_block is None:
+        # Day not yet indexed — write an all-zeros row so consumers can
+        # still distinguish "no data yet" via `computed_at`. The cron
+        # will re-fire on a later day and idempotently overwrite.
+        new_safes = 0
+        multisig_txs_executed = 0
+        native_value_wei = 0
+    else:
+        with connection.cursor() as cursor:
+            cursor.execute(_METRIC_CORE_NEW_SAFES_SQL, [start_block, end_block])
+            new_safes = int(cursor.fetchone()[0] or 0)
+            cursor.execute(
+                _METRIC_CORE_MULTISIG_COUNT_SUM_SQL,
+                [start_block, end_block],
+            )
+            row = cursor.fetchone()
+            multisig_txs_executed = int(row[0] or 0)
+            native_value_wei = int(row[1] or 0)
+
+    module_txs = ModuleTransaction.objects.filter(
+        internal_tx__timestamp__gte=day_start,
+        internal_tx__timestamp__lt=day_end,
+    ).count()
+
+    erc20_transfers = ERC20Transfer.objects.filter(
+        timestamp__gte=day_start,
+        timestamp__lt=day_end,
+    ).count()
+
+    # Read active_safes_daily from the `analytics_dailyactivesafe` rollup
+    # when `_compute_daily_active_safes` has already populated it for this
+    # day — avoids running the expensive 3-leg active-safe union *twice*
+    # per day (once for this count, once for the rollup membership rows).
+    # `_upsert_daily_metric` orders populators so active_safes lands first.
+    # Fallback: compute fresh if the rollup row hasn't been written
+    # (shouldn't happen via the canonical entry point, but keeps the
+    # function safe to call directly in tests).
+    rollup_count = DailyActiveSafe.objects.filter(date=day_start.date()).count()
+    if rollup_count > 0:
+        active_safes_daily = rollup_count
+    else:
+        active_safes_daily = _safes_active_between(day_start, day_end)
+
+    # Same trick for active owners — populator runs immediately after
+    # `active_safes` in the chain so `analytics_dailyactiveowner` already
+    # holds the per-day membership by the time we read it here. Avoids the
+    # expensive `_active_owners_between` Python loop (executed-tx hash
+    # materialisation + N/5000 confirmation joins) on every daily run.
+    owners_rollup_count = DailyActiveOwner.objects.filter(date=day_start.date()).count()
+    if owners_rollup_count > 0:
+        active_owners_daily = owners_rollup_count
+    else:
+        active_owners_daily = _active_owners_between(day_start, day_end)
+
+    obj, _ = DailyMetric.objects.update_or_create(
+        date=day_start.date(),
+        defaults={
+            "new_safes": new_safes,
+            "active_safes": active_safes_daily,
+            "active_owners": active_owners_daily,
+            "multisig_txs_executed": multisig_txs_executed,
+            "module_txs": module_txs,
+            "erc20_transfers": erc20_transfers,
+            "native_value_wei": native_value_wei,
+            "computed_at": timezone.now(),
+        },
+    )
+    return obj
+
+
+# ─────────────── Rollup populators (one per narrow rollup table) ───────
+#
+# All four are idempotent: `INSERT … ON CONFLICT DO UPDATE` for the additive
+# rollups, and `ON CONFLICT DO NOTHING` for the (date, safe_address)
+# membership table. Safe to re-run for the same day window — the daily
+# cron, the backfill management command, and the per-day shard task all
+# share these helpers.
+
+
+def _compute_daily_token_volume(day_start, day_end) -> int:
+    """Populate `analytics_daily_token_volume` for `[day_start, day_end)`.
+
+    One row per (date, token_address). Returns the number of (token) rows
+    written. Spec §2.1 / §3.
+    """
+    date_value = day_start.date()
+    sql = """
+        INSERT INTO analytics_dailytokenvolume
+            (date, token_address, transfer_count, transfer_value, computed_at)
+        SELECT
+            %s::date,
+            address,
+            COUNT(*),
+            COALESCE(SUM(value), 0),
+            NOW()
+        FROM history_erc20transfer
+        WHERE timestamp >= %s AND timestamp < %s
+        GROUP BY address
+        ON CONFLICT (date, token_address) DO UPDATE SET
+            transfer_count = EXCLUDED.transfer_count,
+            transfer_value = EXCLUDED.transfer_value,
+            computed_at    = NOW()
+    """
+    with connection.cursor() as cursor:
+        cursor.execute(sql, [date_value, day_start, day_end])
+        return cursor.rowcount
+
+
+_DAILY_ACTIVE_SAFES_INSERT_SQL = """
+INSERT INTO analytics_dailyactivesafe (date, safe_address)
+SELECT %s::date, addr FROM unnest(%s::bytea[]) AS t(addr)
+ON CONFLICT (date, safe_address) DO NOTHING
+"""
+
+# Multisig leg with block-window pre-resolve. Keyed on `etx.block_id`
+# (FK-indexed) — same shape used by `_DAILY_ACTIVE_OWNERS_SQL` and
+# `_ACTIVE_OWNERS_FALLBACK_SQL`. The prior ORM form
+# (`ethereum_tx__block__timestamp__gte=…`) emitted a 3-table join with the
+# WHERE on `eb.timestamp`, which the planner did not always shape into a
+# nested-loop anchored on the block-range index → on busy chains it timed
+# out before producing rows.
+_DAILY_ACTIVE_SAFES_MULTISIG_LEG_SQL = """
+SELECT DISTINCT mt.safe
+FROM history_multisigtransaction mt
+JOIN history_ethereumtx etx ON mt.ethereum_tx_id = etx.tx_hash
+WHERE etx.block_id >= %s AND etx.block_id < %s
+"""
+
+# Module leg: 2-table join keyed on the directly-indexed
+# `InternalTx.timestamp` btree. No need for the block-window trick here
+# (which the multisig leg needs to dodge a 3-table planner shape); the
+# `(timestamp)` index on `history_internaltx` lets PG range-scan into
+# the day window then nested-loop to `mod_tx` via the FK-indexed
+# `mod_tx.internal_tx_id`. ModuleTransaction is at most 1-3 orders of
+# magnitude less voluminous than MultisigTransaction on production
+# chains; this leg is rarely the bottleneck.
+_DAILY_ACTIVE_SAFES_MODULE_LEG_SQL = """
+SELECT DISTINCT mod_tx.safe
+FROM history_moduletransaction mod_tx
+JOIN history_internaltx it ON mod_tx.internal_tx_id = it.id
+WHERE it.timestamp >= %s AND it.timestamp < %s
+"""
+
+
+def _compute_daily_active_safes(day_start, day_end) -> int:
+    """Populate `analytics_dailyactivesafe` for `[day_start, day_end)`.
+
+    Three-leg union (multisig + module + ERC20) producing the membership
+    set, then bulk-INSERT with `ON CONFLICT DO NOTHING` for idempotency.
+
+    Each leg uses a planner-friendly shape:
+      - Multisig + module legs: block-window pre-resolve (one indexed
+        `MIN(EthereumBlock.number)` sub-ms probe per bound), then
+        anchored on `etx.block_id` (FK-indexed). Same trick as
+        `_DAILY_ACTIVE_OWNERS_SQL` and `_ACTIVE_OWNERS_FALLBACK_SQL`.
+      - ERC20 leg: anchored on SafeContract addresses, probing the
+        existing `(_from, timestamp)` / `(to, timestamp)` covering
+        indexes on `TokenTransfer` in 5000-Safe batches via
+        `_erc20_active_safe_addrs_between`.
+
+    History: an earlier revision UNIONed all four legs in one SQL with
+    a post-EXISTS filter against `history_safecontract`; that scanned
+    the entire ERC20 transfer table for the day window and timed out.
+    The follow-up reused `_safes_active_between_set` which still emitted
+    the multisig leg through `ethereum_tx__block__timestamp__gte=…` ORM
+    join — same bad 3-table-on-timestamp plan, also timed out on busy
+    chains. This revision forces the planner's hand for the multisig
+    and module legs by pre-resolving the block range.
+
+    Block-window approximation: assumes `EthereumBlock.number` is
+    monotonic with `timestamp`. Sub-day L2 sequencer drift is irrelevant
+    at this grain; same trade-off the project already accepted in
+    `_active_owners_in_window`.
+
+    Returns the number of distinct safe rows inserted (excludes rows
+    skipped by `ON CONFLICT`, so reruns return 0).
+    """
+    date_value = day_start.date()
+    start_block, end_block = _resolve_block_window(day_start, day_end)
+    if start_block is None:
+        return 0
+
+    active: set[str] = set()
+    with connection.cursor() as cursor:
+        # Multisig + module legs in two short FK-join queries.
+        cursor.execute(
+            _DAILY_ACTIVE_SAFES_MULTISIG_LEG_SQL,
+            [start_block, end_block],
+        )
+        active.update(_normalize_addr(row[0]) for row in cursor.fetchall())
+        cursor.execute(
+            _DAILY_ACTIVE_SAFES_MODULE_LEG_SQL,
+            [day_start, day_end],
+        )
+        active.update(_normalize_addr(row[0]) for row in cursor.fetchall())
+
+    # ERC20 leg via the existing Safe-anchored batched-EXISTS helper.
+    # Bounded by `len(SafeContract) / batch_size` round-trips × O(1)
+    # per-batch index probe; on a 1.5M-Safe chain that's ~300 round-
+    # trips, each hitting the covering `(_from, timestamp)` /
+    # `(to, timestamp)` index. Tens of seconds on a busy chain.
+    active.update(_erc20_active_safe_addrs_between(day_start, day_end))
+
+    if not active:
+        return 0
+
+    # Address strings come back lowercase-hex from `_normalize_addr`;
+    # `analytics_dailyactivesafe.safe_address` is bytea, so convert once
+    # for the bulk INSERT.
+    address_bytes_all = [bytes.fromhex(a[2:]) for a in active]
+    rows_inserted = 0
+    batch_size = 5000
+    with connection.cursor() as cursor:
+        for i in range(0, len(address_bytes_all), batch_size):
+            batch = address_bytes_all[i : i + batch_size]
+            cursor.execute(
+                _DAILY_ACTIVE_SAFES_INSERT_SQL,
+                [date_value, batch],
+            )
+            rows_inserted += cursor.rowcount
+    return rows_inserted
+
+
+# Block-window range form: pre-resolves day_start / day_end into block-
+# number bounds via the indexed `history_ethereumblock(timestamp)` btree
+# (two scalar sub-queries, sub-ms each), then range-scans
+# `history_ethereumtx.block_id` (FK-indexed) and nested-loops out via
+# FK indexes to `mt` and `mc`. Mirrors the open-ended
+# `_ACTIVE_OWNERS_FALLBACK_SQL` pattern but adds an upper bound for the
+# closed-day range. `COALESCE(..., bigint_max)` keeps the upper-bound
+# predicate well-defined when the chain has not yet indexed past the day
+# (e.g. the daily cron at 01:00 might race the indexer for the most-
+# recent day, in which case we count everything from `start_block`
+# onward — same liberal-upper-bound behaviour as the open-ended form).
+#
+# Approximation: assumes `EthereumBlock.number` is monotonic with
+# `timestamp`. On EVM L2s the worst-case sequencer-pause inversion is a
+# few seconds; irrelevant at day grain. This is the same trade-off the
+# project already accepted in `_active_owners_in_window`.
+_DAILY_ACTIVE_OWNERS_SQL = """
+INSERT INTO analytics_dailyactiveowner (date, owner_address)
+SELECT %s::date, mc.owner
+FROM history_multisigconfirmation mc
+JOIN history_multisigtransaction mt
+    ON mc.multisig_transaction_id = mt.safe_tx_hash
+JOIN history_ethereumtx etx
+    ON mt.ethereum_tx_id = etx.tx_hash
+WHERE etx.block_id >= %s
+  AND etx.block_id <  %s
+GROUP BY mc.owner
+ON CONFLICT (date, owner_address) DO NOTHING
+"""
+
+# Sentinel upper bound when the chain has no block at or past `day_end`.
+# Postgres `bigint` max is 2**63-1; `history_ethereumblock.number` is a
+# `PositiveIntegerField` (32-bit unsigned) so this is comfortably above
+# any real block number.
+_BLOCK_NUMBER_SENTINEL_MAX = 9223372036854775807
+
+
+def _resolve_block_window(day_start, day_end) -> tuple[int | None, int]:
+    """Resolve a `[day_start, day_end)` datetime window into a
+    `[start_block, end_block)` block-number range.
+
+    Two indexed btree probes on `history_ethereumblock(timestamp)`,
+    sub-ms each. Returns `(None, _)` when no block has been indexed at
+    or after `day_start` (the daily cron racing the indexer on the most-
+    recent day, or backfill targeting a date pre-genesis). Returns
+    `(start_block, _BLOCK_NUMBER_SENTINEL_MAX)` when `day_end` resolves
+    to no block (chain hasn't indexed past the day yet) — callers then
+    range-scan from `start_block` to "infinity", same liberal-upper-
+    bound behaviour as the open-ended `_ACTIVE_OWNERS_FALLBACK_SQL`.
+
+    Approximation: assumes `EthereumBlock.number` is monotonic with
+    `timestamp`. Sub-day L2 sequencer drift (~tens of seconds worst
+    case) is irrelevant at day grain. Same trade-off already accepted
+    by `_active_owners_in_window`.
+
+    DRY'd here because every populator that touches the
+    `ethereum_tx → ethereum_block` join needs the same shape — running
+    them all through this helper instead of inlining the two MIN
+    queries lets `_upsert_daily_metric` skip work cleanly on chains
+    that haven't indexed the day yet, and keeps the block-window
+    semantic in one place.
+    """
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "SELECT MIN(number) FROM history_ethereumblock WHERE timestamp >= %s",
+            [day_start],
+        )
+        row = cursor.fetchone()
+        start_block = row[0] if row else None
+        if start_block is None:
+            return None, _BLOCK_NUMBER_SENTINEL_MAX
+        cursor.execute(
+            "SELECT MIN(number) FROM history_ethereumblock WHERE timestamp >= %s",
+            [day_end],
+        )
+        row = cursor.fetchone()
+        end_block = row[0] if row and row[0] is not None else _BLOCK_NUMBER_SENTINEL_MAX
+    return start_block, end_block
+
+
+def _compute_daily_active_owners(day_start, day_end) -> int:
+    """Populate `analytics_dailyactiveowner` for `[day_start, day_end)`.
+
+    Confirmation-based semantic: an owner is "active" on day D if at
+    least one of their multisig-tx confirmations belongs to a multisig
+    tx whose ``EthereumTx.block.timestamp`` lands on day D. One row per
+    distinct owner, idempotent via `ON CONFLICT DO NOTHING`.
+
+    Block-window form: pre-resolves the `[day_start, day_end)` timestamp
+    window into a `[start_block, end_block)` range against
+    `history_ethereumblock` (two indexed sub-ms btree probes), then
+    runs a 3-table FK-join `etx → mt → mc` keyed on `etx.block_id`
+    (FK-indexed) and groups by `mc.owner`. Replaces the prior 4-table
+    join keyed on `eb.timestamp BETWEEN ...` which, on chains with
+    substantial daily activity, did not pick a plan that pruned `etx`
+    early and hit the 30-min `statement_timeout`.
+
+    Returns the number of distinct owner rows inserted (excludes rows
+    skipped by `ON CONFLICT`, so reruns return 0).
+    """
+    date_value = day_start.date()
+    start_block, end_block = _resolve_block_window(day_start, day_end)
+    if start_block is None:
+        return 0
+    with connection.cursor() as cursor:
+        cursor.execute(
+            _DAILY_ACTIVE_OWNERS_SQL,
+            [date_value, start_block, end_block],
+        )
+        return cursor.rowcount
+
+
+def _compute_daily_safe_app_txs(day_start, day_end) -> int:
+    """Populate `analytics_daily_safe_app_txs` for `[day_start, day_end)`.
+
+    Joins multisig → ethereum_tx → ethereum_block to bound by
+    block.timestamp; groups by `origin->>'name'`, skips NULL / empty
+    names. Spec §2.3 / §3.
+
+    Early-exit probe: on chains with no Safe Apps origin metadata at
+    all (BASE today: 0 rows), the 3-way join scans millions of
+    `history_multisigtransaction` rows just to return an empty result.
+    A cheap LIMIT-1 probe on the JSONB filter short-circuits to ~5 ms
+    for those chains. On chains that *do* have origin data, the probe
+    hits the first matching row immediately and the populator runs as
+    before.
+    """
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "SELECT 1 FROM history_multisigtransaction "
+            "WHERE origin->>'name' IS NOT NULL AND origin->>'name' <> '' "
+            "LIMIT 1"
+        )
+        if cursor.fetchone() is None:
+            return 0
+
+    date_value = day_start.date()
+    sql = """
+        INSERT INTO analytics_dailysafeapptx
+            (date, origin_name, origin_url, tx_count)
+        SELECT %s::date, origin_name, origin_url, tx_count FROM (
+            SELECT
+                COALESCE(mt.origin->>'name', '') AS origin_name,
+                COALESCE(MAX(mt.origin->>'url'), '') AS origin_url,
+                COUNT(*) AS tx_count
+            FROM history_multisigtransaction mt
+            JOIN history_ethereumtx etx
+                ON mt.ethereum_tx_id = etx.tx_hash
+            JOIN history_ethereumblock eb
+                ON etx.block_id = eb.number
+            WHERE eb.timestamp >= %s AND eb.timestamp < %s
+              AND mt.origin->>'name' IS NOT NULL
+              AND mt.origin->>'name' <> ''
+            GROUP BY origin_name
+        ) src
+        ON CONFLICT (date, origin_name) DO UPDATE SET
+            origin_url = EXCLUDED.origin_url,
+            tx_count   = EXCLUDED.tx_count
+    """
+    with connection.cursor() as cursor:
+        cursor.execute(sql, [date_value, day_start, day_end])
+        return cursor.rowcount
+
+
+_DAILY_SAFE_CREATIONS_COUNT_SQL = """
+SELECT COUNT(*)
+FROM history_safecontract sc
+JOIN history_ethereumtx etx ON sc.ethereum_tx_id = etx.tx_hash
+WHERE etx.block_id >= %s AND etx.block_id < %s
+"""
+
+
+def _compute_daily_safe_creations(day_start, day_end) -> int:
+    """Populate `analytics_dailysafecreation` for `[day_start, day_end)`.
+
+    One row per day with the count of new Safes whose creating tx
+    landed in the window. Spec §2.4 / §3.
+
+    Block-window form: same shape as `_METRIC_CORE_NEW_SAFES_SQL` (both
+    count SafeContracts whose creating EthereumTx lands in the day's
+    block range). The prior ORM form
+    (`ethereum_tx__block__timestamp__gte=…`) hit the same bad 3-table
+    planner shape as the other timestamp-anchored queries — ~9 min/day
+    on production data.
+    """
+    start_block, end_block = _resolve_block_window(day_start, day_end)
+    if start_block is None:
+        count = 0
+    else:
+        with connection.cursor() as cursor:
+            cursor.execute(_DAILY_SAFE_CREATIONS_COUNT_SQL, [start_block, end_block])
+            count = int(cursor.fetchone()[0] or 0)
+    DailySafeCreation.objects.update_or_create(
+        date=day_start.date(),
+        defaults={"count": count},
+    )
+    return count
+
+
+def _compute_daily_tx_volume(day_start, day_end) -> int:
+    """Populate the proposed/confirmation columns of `analytics_dailymetric`
+    for `[day_start, day_end)`.
+
+    Single SQL round-trip — three subselects share one buffered range
+    scan on `history_multisigconfirmation.created` (via the CTE) and one
+    on `history_multisigtransaction.created`. Idempotent via
+    `ON CONFLICT (date) DO UPDATE`.
+
+    Together with `_compute_daily_metric_core` (which writes the
+    executed-side columns) these three columns let `get_tx_volume` be a
+    pure SUM over the day-rollup — replaces the 5-query live path that
+    timed out at 30s on Base.
+    """
+    date_value = day_start.date()
+    sql = """
+        INSERT INTO analytics_dailymetric (
+            date, new_safes, active_safes, active_owners,
+            multisig_txs_executed, module_txs, erc20_transfers,
+            native_value_wei,
+            multisig_txs_proposed, confirmations_count, confirmed_tx_count,
+            computed_at
+        )
+        SELECT
+            %s::date, 0, 0, 0, 0, 0, 0, 0,
+            (SELECT COUNT(*) FROM history_multisigtransaction
+                WHERE created >= %s AND created < %s),
+            c.confs, c.tx_cnt,
+            NOW()
+        FROM (
+            SELECT
+                COUNT(*)                                  AS confs,
+                COUNT(DISTINCT multisig_transaction_id)   AS tx_cnt
+            FROM history_multisigconfirmation
+            WHERE created >= %s AND created < %s
+        ) c
+        ON CONFLICT (date) DO UPDATE SET
+            multisig_txs_proposed = EXCLUDED.multisig_txs_proposed,
+            confirmations_count   = EXCLUDED.confirmations_count,
+            confirmed_tx_count    = EXCLUDED.confirmed_tx_count,
+            computed_at           = NOW()
+    """
+    with connection.cursor() as cursor:
+        cursor.execute(
+            sql,
+            [
+                date_value,
+                day_start,
+                day_end,  # MultisigTransaction subselect
+                day_start,
+                day_end,  # MultisigConfirmation CTE
+            ],
+        )
+        return cursor.rowcount
+
+
+def _safes_active_between_set(start, end) -> set[str]:
+    """Same body as `_safes_active_between` but returns the set instead of
+    just the cardinality. Split out so `_compute_daily_active_safes` can
+    persist the membership without re-running the (expensive) union.
+    """
+    active: set[str] = set()
+    active.update(
+        _normalize_addr(a)
+        for a in MultisigTransaction.objects.filter(
+            ethereum_tx__block__timestamp__gte=start,
+            ethereum_tx__block__timestamp__lt=end,
+        )
+        .values_list("safe", flat=True)
+        .distinct()
+    )
+    active.update(
+        _normalize_addr(a)
+        for a in ModuleTransaction.objects.filter(
+            internal_tx__timestamp__gte=start,
+            internal_tx__timestamp__lt=end,
+        )
+        .values_list("safe", flat=True)
+        .distinct()
+    )
+    active.update(_erc20_active_safe_addrs_between(start, end))
+    return active
+
+
+def _upsert_daily_metric(day_start, day_end) -> DailyMetric:
+    """Run the 6-step single-day populate path: 5 narrow rollup tables
+    plus the `DailyMetric` core upsert.
+
+    Population order matters: the membership populators (`active_safes`,
+    `active_owners`) run FIRST so their rollups are populated before
+    `_compute_daily_metric_core` reads its `active_safes_daily` /
+    `active_owners_daily` counts from them. Without this ordering the
+    same expensive aggregates run twice per day (once for the count,
+    once for the rollup rows) — on BASE that doubles wall time.
+
+    Per-populator failures are isolated so one slow / failing populator
+    does not strand the others.
+    """
+    # Time each populator so operators can localise slow chains via logs
+    # without having to ssh + py-spy. Cheap (one logger call per day per
+    # populator).
+    populator_order = (
+        ("active_safes", _compute_daily_active_safes),
+        ("active_owners", _compute_daily_active_owners),
+        ("token_volume", _compute_daily_token_volume),
+        ("tx_volume", _compute_daily_tx_volume),
+        ("safe_app_txs", _compute_daily_safe_app_txs),
+        ("safe_creations", _compute_daily_safe_creations),
+    )
+    day_label = day_start.date()
+    overall_started = time.time()
+    logger.info(
+        "_upsert_daily_metric: starting day=%s populators=%d",
+        day_label,
+        len(populator_order),
+    )
+    for name, fn in populator_order:
+        step_started = time.time()
+        try:
+            rows = fn(day_start, day_end)
+            logger.info(
+                "_upsert_daily_metric: rollup %s took %.2fs day=%s rows=%s",
+                name,
+                time.time() - step_started,
+                day_label,
+                rows,
+            )
+        except Exception:
+            logger.exception(
+                "_upsert_daily_metric: rollup %s failed in %.2fs day=%s",
+                name,
+                time.time() - step_started,
+                day_label,
+            )
+
+    # Core last so it can SELECT COUNT(*) from analytics_dailyactivesafe
+    # instead of re-running _safes_active_between.
+    core_started = time.time()
+    obj = _compute_daily_metric_core(day_start, day_end)
+    logger.info(
+        "_upsert_daily_metric: metric_core took %.2fs day=%s "
+        "active_safes=%d active_owners=%d multisig_txs_executed=%d",
+        time.time() - core_started,
+        day_label,
+        obj.active_safes,
+        obj.active_owners,
+        obj.multisig_txs_executed,
+    )
+    logger.info(
+        "_upsert_daily_metric: completed in %.2fs day=%s",
+        time.time() - overall_started,
+        day_label,
+    )
+    return obj
+
+
+def _refresh_active_window_caches(now) -> None:
+    """Recompute the rolling-window distinct active_safes / active_owners
+    counts and write to the existing Redis keys. Preserves today's
+    window-distinct semantics on the read path (see plan §C7 / Q1)."""
+    redis = get_redis()
+    for window_str, days in [("7d", 7), ("30d", 30), ("90d", 90)]:
+        cutoff = now - timezone.timedelta(days=days)
+        step_started = time.time()
+        try:
+            safes_count = _safes_active_in_window(cutoff)
+            redis.set(
+                AnalyticsService.REDIS_ACTIVE_SAFES_PREFIX + window_str,
+                json.dumps(
+                    {
+                        "window": window_str,
+                        "active_safes": safes_count,
+                        "computed_at": now.isoformat(),
+                    }
+                ),
+            )
+            logger.info(
+                "_refresh_active_window_caches: active_safes %s took %.2fs count=%d",
+                window_str,
+                time.time() - step_started,
+                safes_count,
+            )
+        except Exception:
+            logger.exception(
+                "_refresh_active_window_caches: active_safes %s failed after %.2fs",
+                window_str,
+                time.time() - step_started,
+            )
+        step_started = time.time()
+        try:
+            owners_count = _active_owners_in_window(cutoff)
+            redis.set(
+                AnalyticsService.REDIS_ACTIVE_OWNERS_PREFIX + window_str,
+                json.dumps(
+                    {
+                        "window": window_str,
+                        "active_owners": owners_count,
+                        "computed_at": now.isoformat(),
+                    }
+                ),
+            )
+            logger.info(
+                "_refresh_active_window_caches: active_owners %s took %.2fs count=%d",
+                window_str,
+                time.time() - step_started,
+                owners_count,
+            )
+        except Exception:
+            logger.exception(
+                "_refresh_active_window_caches: active_owners %s failed after %.2fs",
+                window_str,
+                time.time() - step_started,
+            )
+
+
+@app.shared_task(bind=True)
+@task_timeout(timeout_seconds=LOCK_TIMEOUT * 4)
+def compute_daily_metrics_task(self, days_back: int = 1) -> bool:
+    """Upsert `DailyMetric` rows for the last `days_back` complete UTC days
+    and refresh the rolling-window distinct active_* Redis keys.
+
+    Default `days_back=1` runs the previous-day metric daily. The same task
+    is invoked by the `backfill_daily_metrics` management command with a
+    larger range for one-shot history loads. Per-day try/except so a single
+    bad day doesn't strand the rest of the run.
+
+    Guarded by ``only_one_running_task(self)`` so the 01:00 cron and a
+    manual ``.delay()`` (or a backfill shard for the same date range)
+    cannot race the same ``update_or_create`` and trip ``IntegrityError``
+    on the ``analytics_dailymetric`` PK.
+    """
+    with contextlib.suppress(LockError):
+        with only_one_running_task(self):
+            started = time.time()
+            now = timezone.now()
+            today_utc_midnight = now.replace(hour=0, minute=0, second=0, microsecond=0)
+            logger.info("compute_daily_metrics_task: starting days_back=%d", days_back)
+            written = 0
+            with relaxed_statement_timeout():
+                for offset in range(1, days_back + 1):
+                    day_start = today_utc_midnight - timezone.timedelta(days=offset)
+                    day_end = day_start + timezone.timedelta(days=1)
+                    try:
+                        _upsert_daily_metric(day_start, day_end)
+                        written += 1
+                    except Exception:
+                        logger.exception(
+                            "compute_daily_metrics_task: day %s failed",
+                            day_start.date(),
+                        )
+                        continue
+                refresh_started = time.time()
+                try:
+                    _refresh_active_window_caches(today_utc_midnight)
+                    logger.info(
+                        "compute_daily_metrics_task: rolling-window refresh took %.2fs",
+                        time.time() - refresh_started,
+                    )
+                except Exception:
+                    logger.exception(
+                        "compute_daily_metrics_task: rolling-window refresh "
+                        "failed after %.2fs",
+                        time.time() - refresh_started,
+                    )
+            logger.info(
+                "compute_daily_metrics_task: completed in %.2fs days_written=%d/%d",
+                time.time() - started,
+                written,
+                days_back,
+            )
+            return written > 0

--- a/safe_transaction_service/analytics/tasks_shards.py
+++ b/safe_transaction_service/analytics/tasks_shards.py
@@ -1,0 +1,426 @@
+"""Sharded Celery tasks for analytics (Option 5 in
+``SCALING_ARCHITECTURE.md``).
+
+Two independent fan-outs live here:
+
+1. **Native-balance sharding** (``compute_native_balance_shard`` +
+   ``reduce_native_balance_shards``) — splits the all-Safes native-balance
+   compute by first hex nibble of the Safe address so the wall-clock drops
+   ~16× on BASE-sized fleets, gated by the worker pool size.
+2. **Backfill sharding** (``_compute_daily_metric_shard`` +
+   ``_backfill_done``) — one Celery task per UTC day for the
+   ``backfill_daily_metrics`` management command.
+
+Both shapes use the celery primitives `group` / `chord`; both are eager-mode
+safe so they run inline during tests without a broker.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from datetime import date, datetime, timedelta
+
+from django.db import connection
+from django.db.models import Count, Sum
+from django.utils import timezone
+
+from celery import app, chord, group
+
+from safe_transaction_service.analytics.services.db import relaxed_statement_timeout
+from safe_transaction_service.history.models import ERC20Transfer, SafeContract
+from safe_transaction_service.utils.celery import task_timeout
+from safe_transaction_service.utils.redis import get_redis
+from safe_transaction_service.utils.tasks import LOCK_TIMEOUT
+
+logger = logging.getLogger(__name__)
+
+
+# 16 first-nibble shards. The BASE worker pool is on the order of 8–16
+# concurrent slots; 16 saturates without queue backlog. Bump to 256
+# (two-nibble) only if pool size grows past 16.
+HEX_PREFIXES: tuple[str, ...] = tuple("0123456789abcdef")
+
+# Redis key holding the most-recent backfill summary written by
+# `backfill_done` — useful for `manage.py backfill_daily_metrics --wait`
+# style polling.
+BACKFILL_CURSOR_KEY = "analytics_backfill_cursor"
+
+
+# ────────────────────── Native-balance sharding ────────────────────────
+
+
+def _safe_addresses_for_prefix(prefix: str) -> list[bytes]:
+    """Return the address-bytes for every SafeContract whose first hex
+    nibble equals ``prefix``.
+
+    ``SafeContract.address`` is the bytea PK, so the first hex nibble is
+    the high 4 bits of byte 0. Filter by an indexed PK range
+    ``[N0…00, NF…FF]`` and PG does a single range-scan of ~N/16 rows —
+    the prior form iterated every row of ``history_safecontract`` and
+    filtered in Python, costing 16 full table scans (one per shard) per
+    TVL run.
+    """
+    nibble = int(prefix, 16)
+    lo = bytes([nibble << 4]) + b"\x00" * 19
+    hi = bytes([(nibble << 4) | 0x0F]) + b"\xff" * 19
+    qs = SafeContract.objects.filter(address__gte=lo, address__lte=hi).values_list(
+        "address", flat=True
+    )
+    return [bytes.fromhex(addr[2:]) for addr in qs.iterator(chunk_size=10_000)]
+
+
+def _balance_for_addresses(address_bytes: list[bytes]) -> tuple[int, int]:
+    """Run the existing batched balance SQL against an explicit address
+    list. Returns ``(balance_wei, safes_with_balance)``.
+    """
+    # Local import — `tasks` imports `tasks_shards` only inside the chord
+    # dispatcher (lazy), so we can safely import the legacy SQL constant
+    # here.
+    from safe_transaction_service.analytics.tasks import BALANCE_BATCH_SQL
+
+    if not address_bytes:
+        return 0, 0
+    batch_size = 5000
+    total_balance_wei = 0
+    total_safes_with_balance = 0
+    for offset in range(0, len(address_bytes), batch_size):
+        batch = address_bytes[offset : offset + batch_size]
+        with connection.cursor() as cursor:
+            cursor.execute(BALANCE_BATCH_SQL, [batch, batch])
+            row = cursor.fetchone()
+        total_balance_wei += int(row[0]) if row and row[0] else 0
+        total_safes_with_balance += int(row[1]) if row and row[1] else 0
+    return total_balance_wei, total_safes_with_balance
+
+
+@app.shared_task()
+@task_timeout(timeout_seconds=LOCK_TIMEOUT)
+def compute_native_balance_shard(prefix: str) -> dict:
+    """One of the 16 hex-prefix shards of ``_calculate_native_balances_from_db``.
+
+    Each shard owns ~1/16 of the SafeContract address space and runs the
+    same batched ``BALANCE_BATCH_SQL`` over its slice. The reduce step
+    sums everything back into the same shape the legacy single-task path
+    produced — no service-layer changes needed downstream.
+
+    On transient PG failure (statement timeout, broken connection, …) the
+    shard returns ``{prefix, balance_wei: 0, safes_with_balance: 0,
+    failed: True, error: <str>}`` rather than raising. Raising would
+    propagate into the chord header and skip the body
+    (``reduce_native_balance_shards | finalize_tvl_snapshot``) entirely,
+    leaving the snapshot frozen at the phase-1 placeholder. Returning a
+    zero stub lets ``reduce_native_balance_shards`` exclude the shard
+    from the sum, surface ``partial_shards`` in the payload, and still
+    invoke ``finalize_tvl_snapshot`` so the snapshot stays current.
+    """
+    started = time.time()
+    logger.info("compute_native_balance_shard: starting prefix=%s", prefix)
+    try:
+        with relaxed_statement_timeout():
+            address_bytes = _safe_addresses_for_prefix(prefix)
+            balance_wei, safes_with_balance = _balance_for_addresses(address_bytes)
+    except Exception as exc:
+        logger.exception(
+            "compute_native_balance_shard: prefix=%s failed after %.2fs",
+            prefix,
+            time.time() - started,
+        )
+        return {
+            "prefix": prefix,
+            "balance_wei": 0,
+            "safes_with_balance": 0,
+            "failed": True,
+            "error": str(exc)[:500],
+        }
+    logger.info(
+        "compute_native_balance_shard: completed in %.2fs prefix=%s "
+        "addresses=%d safes_with_balance=%d balance_wei=%d",
+        time.time() - started,
+        prefix,
+        len(address_bytes),
+        safes_with_balance,
+        balance_wei,
+    )
+    return {
+        "prefix": prefix,
+        "balance_wei": balance_wei,
+        "safes_with_balance": safes_with_balance,
+    }
+
+
+@app.shared_task()
+@task_timeout(timeout_seconds=LOCK_TIMEOUT)
+def reduce_native_balance_shards(shards: list[dict]) -> dict:
+    """Sum the shard results and return the same `(balance, count)` pair
+    the legacy single-task path produced.
+
+    Skips shards marked ``failed=True`` (see ``compute_native_balance_shard``)
+    and reports the partial-shard count via ``partial_shards`` so the
+    chord callback (``finalize_tvl_snapshot``) can surface it in the
+    snapshot payload. Tolerates ``None`` entries defensively in case a
+    future Celery version inserts them for tasks that hit ``task_timeout``
+    with ``raise_exception=False``.
+    """
+    safe_shards = [s for s in shards if isinstance(s, dict) and not s.get("failed")]
+    partial_shards = len(shards) - len(safe_shards)
+    total = {
+        "balance_wei": sum(int(s.get("balance_wei", 0)) for s in safe_shards),
+        "safes_with_balance": sum(
+            int(s.get("safes_with_balance", 0)) for s in safe_shards
+        ),
+        "partial_shards": partial_shards,
+        "total_shards": len(shards),
+    }
+    logger.info(
+        "reduce_native_balance_shards: completed shards=%d ok=%d failed=%d "
+        "safes_with_balance=%d balance_wei=%d",
+        len(shards),
+        len(safe_shards),
+        partial_shards,
+        total["safes_with_balance"],
+        total["balance_wei"],
+    )
+    return total
+
+
+@app.shared_task()
+@task_timeout(timeout_seconds=LOCK_TIMEOUT * 2)
+def finalize_tvl_snapshot(reduced: dict) -> bool:
+    """Chord callback that turns the reduced native balance into the final
+    ``tvl`` snapshot.
+
+    Receives ``{"balance_wei", "safes_with_balance"}`` from
+    ``reduce_native_balance_shards``, runs the ERC20 net-flow aggregation,
+    and overwrites the phase-1 placeholder ``compute_tvl_task`` wrote up
+    front. Living in the chord callback (instead of the parent task) is
+    what removes the synchronous ``.get()`` block that previously had
+    ``compute_tvl_task`` hanging on a result key the gevent worker pool
+    sometimes never observed.
+
+    Failure stays local: the placeholder snapshot is left in place so the
+    endpoint keeps serving a coherent zero payload until the next run.
+    """
+    # Local import — ``tasks`` imports ``tasks_shards`` at module load to
+    # register the chord members, so the reverse edge has to stay lazy.
+    from safe_transaction_service.analytics.tasks import _write_snapshot
+
+    started = time.time()
+    native_balance_wei = int(reduced.get("balance_wei", 0))
+    total_safes_with_balance = int(reduced.get("safes_with_balance", 0))
+    partial_shards = int(reduced.get("partial_shards", 0))
+    total_shards = int(reduced.get("total_shards", 0))
+
+    try:
+        safe_addrs_subq = SafeContract.objects.values("address")
+
+        with relaxed_statement_timeout():
+            erc20_incoming = (
+                ERC20Transfer.objects.filter(to__in=safe_addrs_subq)
+                .values("address")
+                .annotate(total_in=Sum("value"))
+            )
+            erc20_outgoing = (
+                ERC20Transfer.objects.filter(_from__in=safe_addrs_subq)
+                .values("address")
+                .annotate(total_out=Sum("value"))
+            )
+
+            token_balances: dict[str, int] = {}
+            for row in erc20_incoming:
+                token_balances[row["address"]] = row["total_in"] or 0
+            for row in erc20_outgoing:
+                addr = row["address"]
+                token_balances[addr] = token_balances.get(addr, 0) - (
+                    row["total_out"] or 0
+                )
+            token_balances = {a: b for a, b in token_balances.items() if b > 0}
+
+            token_safe_counts: dict[str, int] = (
+                dict(
+                    ERC20Transfer.objects.filter(
+                        to__in=safe_addrs_subq,
+                        address__in=list(token_balances),
+                    )
+                    .values_list("address")
+                    .annotate(safe_count=Count("to", distinct=True))
+                    .values_list("address", "safe_count")
+                )
+                if token_balances
+                else {}
+            )
+
+        top_tokens = sorted(token_balances.items(), key=lambda x: x[1], reverse=True)[
+            :20
+        ]
+        payload = {
+            "total_safes_with_balance": total_safes_with_balance,
+            "native_balance_wei": str(native_balance_wei),
+            "erc20_token_count": len(token_balances),
+            "top_tokens": [
+                {
+                    "address": addr,
+                    "total_balance": str(bal),
+                    "safe_count": token_safe_counts.get(addr, 0),
+                }
+                for addr, bal in top_tokens
+            ],
+            # Surface partial-shard state so consumers can detect that
+            # this snapshot was computed from a subset of the address
+            # space (one or more shards failed). When zero shards
+            # failed both fields are zero/total and the payload reads
+            # as fully-computed.
+            "partial_shards": partial_shards,
+            "total_shards": total_shards,
+            "computed_at": timezone.now().isoformat(),
+        }
+        _write_snapshot("tvl", payload)
+        logger.info(
+            "finalize_tvl_snapshot: completed in %.2fs native_wei=%d "
+            "safes_with_balance=%d erc20_tokens=%d partial_shards=%d/%d",
+            time.time() - started,
+            native_balance_wei,
+            total_safes_with_balance,
+            len(token_balances),
+            partial_shards,
+            total_shards,
+        )
+        return True
+    except Exception:
+        logger.exception(
+            "finalize_tvl_snapshot: failed after %.2fs during ERC20 "
+            "aggregation; keeping phase-1 placeholder snapshot",
+            time.time() - started,
+        )
+        return False
+
+
+def dispatch_tvl_chord() -> None:
+    """Fire-and-forget the TVL chord.
+
+    Builds ``(16 native shards) → reduce_native_balance_shards →
+    finalize_tvl_snapshot`` and submits it to the ``contracts`` queue.
+    The parent task (``compute_tvl_task``) does NOT block — the final
+    snapshot is written by ``finalize_tvl_snapshot`` when the chord
+    resolves. Eager mode runs the whole chain inline.
+    """
+    job = chord(
+        (compute_native_balance_shard.s(p) for p in HEX_PREFIXES),
+        reduce_native_balance_shards.s() | finalize_tvl_snapshot.s(),
+    )
+    job.apply_async(queue="contracts")
+
+
+# ────────────────────── Backfill sharding ──────────────────────────────
+
+
+def _parse_iso_date(value: str | date | datetime) -> date:
+    if isinstance(value, date) and not isinstance(value, datetime):
+        return value
+    if isinstance(value, datetime):
+        return value.date()
+    return datetime.strptime(value, "%Y-%m-%d").date()
+
+
+@app.shared_task()
+@task_timeout(timeout_seconds=LOCK_TIMEOUT * 4)
+def compute_daily_metric_shard(day_iso: str) -> dict:
+    """One backfill shard — compute and upsert the DailyMetric row plus all
+    four narrow rollup tables for the given UTC day.
+
+    `_upsert_daily_metric` already runs the 5-step inline path; this is a
+    thin Celery-task wrapper so the backfill management command can group-
+    dispatch one task per day and let the worker pool naturally cap
+    concurrency.
+    """
+    # Local import — keeps the tasks_shards <-> tasks edge lazy so module
+    # import order in Celery autodiscovery doesn't matter.
+    from safe_transaction_service.analytics.tasks import _upsert_daily_metric
+
+    day = _parse_iso_date(day_iso)
+    tz = timezone.get_current_timezone()
+    day_start = datetime.combine(day, datetime.min.time(), tzinfo=tz)
+    day_end = day_start + timedelta(days=1)
+    started = time.time()
+    logger.info("compute_daily_metric_shard: starting day=%s", day_iso)
+    try:
+        with relaxed_statement_timeout():
+            _upsert_daily_metric(day_start, day_end)
+    except Exception as e:  # noqa: BLE001 — per-day isolation
+        logger.exception(
+            "compute_daily_metric_shard: failed after %.2fs day=%s",
+            time.time() - started,
+            day_iso,
+        )
+        return {"date": day_iso, "ok": False, "error": str(e)}
+    elapsed = time.time() - started
+    logger.info(
+        "compute_daily_metric_shard: completed in %.2fs day=%s",
+        elapsed,
+        day_iso,
+    )
+    return {
+        "date": day_iso,
+        "ok": True,
+        "elapsed_seconds": round(elapsed, 2),
+    }
+
+
+@app.shared_task()
+@task_timeout(timeout_seconds=LOCK_TIMEOUT)
+def backfill_done(shard_results: list[dict], stats_key: str | None = None) -> dict:
+    """Chord callback for `backfill_daily_metrics`.
+
+    Aggregates the per-day shard results and writes a small summary blob
+    to Redis at `stats_key` (defaults to BACKFILL_CURSOR_KEY) so the
+    management command can poll for completion.
+    """
+    written = sum(1 for r in shard_results if r.get("ok"))
+    failed = sum(1 for r in shard_results if not r.get("ok"))
+    failures = [r for r in shard_results if not r.get("ok")][:50]
+    summary = {
+        "total": len(shard_results),
+        "written": written,
+        "failed": failed,
+        "failures": failures,
+        "finished_at": timezone.now().isoformat(),
+    }
+    key = stats_key or BACKFILL_CURSOR_KEY
+    get_redis().set(key, json.dumps(summary))
+    logger.info(
+        "backfill_done: completed days_written=%d/%d failed=%d summary_key=%s",
+        written,
+        len(shard_results),
+        failed,
+        key,
+    )
+    return summary
+
+
+def dispatch_backfill(dates: list[date], stats_key: str | None = None):
+    """Build the backfill chord — one shard per UTC day, summary written
+    on completion. Returns the AsyncResult; callers can ``.get(timeout=…)``
+    to block on completion.
+
+    Eager mode works identically via the Redis result backend configured
+    in `config/settings/base.py`.
+    """
+    key = stats_key or BACKFILL_CURSOR_KEY
+    job = group(
+        compute_daily_metric_shard.s(d.isoformat()) for d in dates
+    ) | backfill_done.s(key)
+    return job.apply_async(queue="contracts")
+
+
+__all__ = [
+    "HEX_PREFIXES",
+    "BACKFILL_CURSOR_KEY",
+    "compute_native_balance_shard",
+    "reduce_native_balance_shards",
+    "finalize_tvl_snapshot",
+    "dispatch_tvl_chord",
+    "compute_daily_metric_shard",
+    "backfill_done",
+    "dispatch_backfill",
+]

--- a/safe_transaction_service/analytics/tests/test_tasks.py
+++ b/safe_transaction_service/analytics/tests/test_tasks.py
@@ -1,14 +1,178 @@
 import json
+from unittest.mock import patch
 
 from django.test import TestCase
 
+from safe_transaction_service.analytics.models import (
+    AnalyticsSnapshot,
+    DailyActiveOwner,
+    DailyMetric,
+)
 from safe_transaction_service.analytics.services.analytics_service import (
     AnalyticsService,
 )
-from safe_transaction_service.analytics.tasks import get_transactions_per_safe_app_task
-from safe_transaction_service.history.models import MultisigTransaction
-from safe_transaction_service.history.tests.factories import MultisigTransactionFactory
+from safe_transaction_service.analytics.services.db import approx_count_or_exact
+from safe_transaction_service.analytics.tasks import (
+    _active_owners_in_window,
+    _calculate_native_balances_from_db,
+    _safes_active_in_window,
+    _upsert_daily_metric,
+    compute_active_owners_task,
+    compute_active_safes_task,
+    compute_daily_metrics_task,
+    compute_safe_creations_task,
+    compute_summary_task,
+    get_transactions_per_safe_app_task,
+)
+from safe_transaction_service.history.models import (
+    EthereumTxCallType,
+    MultisigTransaction,
+    SafeContract,
+)
+from safe_transaction_service.history.tests.factories import (
+    ERC20TransferFactory,
+    ERC721TransferFactory,
+    InternalTxFactory,
+    ModuleTransactionFactory,
+    MultisigConfirmationFactory,
+    MultisigTransactionFactory,
+    SafeContractFactory,
+    SafeStatusFactory,
+)
 from safe_transaction_service.utils.redis import get_redis
+
+
+class TestCalculateNativeBalancesFromDb(TestCase):
+    def test_empty_safe_contracts(self):
+        total_balance, safes_with_balance = _calculate_native_balances_from_db()
+        self.assertEqual(total_balance, 0)
+        self.assertEqual(safes_with_balance, 0)
+
+    def test_safe_with_only_incoming(self):
+        safe = SafeContractFactory()
+        InternalTxFactory(
+            to=safe.address,
+            value=1000,
+            call_type=EthereumTxCallType.CALL.value,
+            error=None,
+        )
+        total_balance, safes_with_balance = _calculate_native_balances_from_db()
+        self.assertEqual(total_balance, 1000)
+        self.assertEqual(safes_with_balance, 1)
+
+    def test_safe_with_only_outgoing(self):
+        safe = SafeContractFactory()
+        InternalTxFactory(
+            _from=safe.address,
+            value=500,
+            call_type=EthereumTxCallType.CALL.value,
+            error=None,
+        )
+        total_balance, safes_with_balance = _calculate_native_balances_from_db()
+        self.assertEqual(total_balance, 0)
+        self.assertEqual(safes_with_balance, 0)
+
+    def test_safe_with_positive_net_balance(self):
+        safe = SafeContractFactory()
+        InternalTxFactory(
+            to=safe.address,
+            value=1000,
+            call_type=EthereumTxCallType.CALL.value,
+            error=None,
+        )
+        InternalTxFactory(
+            _from=safe.address,
+            value=300,
+            call_type=EthereumTxCallType.CALL.value,
+            error=None,
+        )
+        total_balance, safes_with_balance = _calculate_native_balances_from_db()
+        self.assertEqual(total_balance, 700)
+        self.assertEqual(safes_with_balance, 1)
+
+    def test_safe_with_zero_net_balance(self):
+        safe = SafeContractFactory()
+        InternalTxFactory(
+            to=safe.address,
+            value=500,
+            call_type=EthereumTxCallType.CALL.value,
+            error=None,
+        )
+        InternalTxFactory(
+            _from=safe.address,
+            value=500,
+            call_type=EthereumTxCallType.CALL.value,
+            error=None,
+        )
+        total_balance, safes_with_balance = _calculate_native_balances_from_db()
+        self.assertEqual(total_balance, 0)
+        self.assertEqual(safes_with_balance, 0)
+
+    def test_error_transactions_excluded(self):
+        safe = SafeContractFactory()
+        # Successful incoming
+        InternalTxFactory(
+            to=safe.address,
+            value=1000,
+            call_type=EthereumTxCallType.CALL.value,
+            error=None,
+        )
+        # Failed incoming — should be excluded
+        InternalTxFactory(
+            to=safe.address,
+            value=5000,
+            call_type=EthereumTxCallType.CALL.value,
+            error="Reverted",
+        )
+        total_balance, safes_with_balance = _calculate_native_balances_from_db()
+        self.assertEqual(total_balance, 1000)
+        self.assertEqual(safes_with_balance, 1)
+
+    def test_non_safe_address_excluded(self):
+        """InternalTx for addresses not in SafeContract should not be counted."""
+        safe = SafeContractFactory()
+        # Incoming to the Safe
+        InternalTxFactory(
+            to=safe.address,
+            value=100,
+            call_type=EthereumTxCallType.CALL.value,
+            error=None,
+        )
+        # Incoming to a non-Safe address (no SafeContract record)
+        InternalTxFactory(
+            value=9999,
+            call_type=EthereumTxCallType.CALL.value,
+            error=None,
+        )
+        total_balance, safes_with_balance = _calculate_native_balances_from_db()
+        self.assertEqual(total_balance, 100)
+        self.assertEqual(safes_with_balance, 1)
+
+    def test_multiple_safes(self):
+        safe1 = SafeContractFactory()
+        safe2 = SafeContractFactory()
+        InternalTxFactory(
+            to=safe1.address,
+            value=2000,
+            call_type=EthereumTxCallType.CALL.value,
+            error=None,
+        )
+        InternalTxFactory(
+            to=safe2.address,
+            value=3000,
+            call_type=EthereumTxCallType.CALL.value,
+            error=None,
+        )
+        InternalTxFactory(
+            _from=safe2.address,
+            value=1000,
+            call_type=EthereumTxCallType.CALL.value,
+            error=None,
+        )
+        total_balance, safes_with_balance = _calculate_native_balances_from_db()
+        # safe1: 2000, safe2: 3000-1000=2000
+        self.assertEqual(total_balance, 4000)
+        self.assertEqual(safes_with_balance, 2)
 
 
 class TestTasks(TestCase):
@@ -53,3 +217,962 @@ class TestTasks(TestCase):
         analytic = json.loads(value)
 
         self.assertEqual(analytic, expected)
+
+    def test_compute_summary_task_writes_snapshot(self):
+        """`compute_summary_task` populates the `summary` row in
+        `analytics_analyticssnapshot` and writes nothing to Redis."""
+        redis = get_redis()
+        redis.flushall()
+
+        SafeContractFactory()
+        SafeContractFactory()
+        MultisigTransactionFactory()
+        ModuleTransactionFactory()
+        ERC20TransferFactory()
+        ERC721TransferFactory()
+
+        compute_summary_task.delay()
+
+        summary = AnalyticsSnapshot.objects.get(name="summary").payload
+        self.assertEqual(summary["total_safes"], 2)
+        self.assertEqual(summary["total_multisig_txs"], 1)
+        self.assertEqual(summary["total_module_txs"], 1)
+        self.assertEqual(summary["total_erc20_transfers"], 1)
+        self.assertEqual(summary["total_erc721_transfers"], 1)
+        self.assertIsNotNone(summary["first_safe_created"])
+        self.assertIsNotNone(summary["last_safe_created"])
+        self.assertIsNotNone(summary["computed_at"])
+
+        # Legacy Redis key must not be written.
+        self.assertIsNone(redis.get(AnalyticsService.REDIS_SUMMARY))
+        # `safe_statistics` snapshot must not be produced — the endpoint
+        # was retired and this task no longer writes that row.
+        self.assertFalse(
+            AnalyticsSnapshot.objects.filter(name="safe_statistics").exists()
+        )
+
+    def test_compute_summary_task_empty_db_writes_snapshot_with_zeros(self):
+        redis = get_redis()
+        redis.flushall()
+        AnalyticsSnapshot.objects.all().delete()
+
+        compute_summary_task.delay()
+
+        summary = AnalyticsSnapshot.objects.get(name="summary").payload
+        self.assertEqual(summary["total_safes"], 0)
+        self.assertEqual(summary["total_multisig_txs"], 0)
+        self.assertEqual(summary["total_module_txs"], 0)
+        self.assertIsNone(summary["first_safe_created"])
+        self.assertIsNone(summary["last_safe_created"])
+        self.assertIsNotNone(summary["computed_at"])
+
+    def test_compute_safe_creations_task_writes_day_series(self):
+        redis = get_redis()
+        redis.flushall()
+
+        SafeContractFactory()
+        SafeContractFactory()
+        SafeContractFactory()
+
+        compute_safe_creations_task()
+
+        payload = json.loads(redis.get(AnalyticsService.REDIS_SAFE_CREATIONS))
+        self.assertIn("series", payload)
+        self.assertIn("computed_at", payload)
+        self.assertIsNotNone(payload["computed_at"])
+
+        total = sum(row["count"] for row in payload["series"])
+        self.assertEqual(total, 3)
+        for row in payload["series"]:
+            self.assertIn("period", row)
+            self.assertIn("count", row)
+            # period is an ISO date string, not a datetime
+            self.assertEqual(len(row["period"]), 10)
+
+    def test_compute_safe_creations_task_empty_writes_empty_series(self):
+        redis = get_redis()
+        redis.flushall()
+
+        compute_safe_creations_task()
+
+        payload = json.loads(redis.get(AnalyticsService.REDIS_SAFE_CREATIONS))
+        self.assertEqual(payload["series"], [])
+        self.assertIsNotNone(payload["computed_at"])
+
+
+class TestApproxCountOrExact(TestCase):
+    """`approx_count_or_exact` should serve the planner estimate on large
+    tables and fall back to exact `COUNT(*)` on small / freshly-fixtured
+    tables so unit tests don't depend on ANALYZE having been run."""
+
+    def test_falls_back_to_exact_when_reltuples_below_threshold(self):
+        SafeContractFactory()
+        SafeContractFactory()
+        SafeContractFactory()
+        # pg_class.reltuples on a freshly-populated table is 0 or -1 until
+        # ANALYZE runs, so the helper must fall back to exact COUNT(*).
+        self.assertEqual(
+            approx_count_or_exact(SafeContract, "history_safecontract", threshold=1000),
+            3,
+        )
+
+    def test_returns_reltuples_when_above_threshold(self):
+        # Force the approx path by lowering the threshold below the real
+        # estimate. ANALYZE on a 0-row table leaves reltuples at 0, so we
+        # patch the cursor to simulate a populated table.
+        SafeContractFactory()
+
+        class _FakeCursorCM:
+            def __init__(self, value):
+                self._value = value
+
+            def __enter__(self):
+                self._exec_count = 0
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+            def execute(self, sql, params):
+                self._sql = sql
+                self._params = params
+
+            def fetchone(self):
+                return (self._value,)
+
+        from safe_transaction_service.analytics.services import db as db_helpers
+
+        with patch.object(
+            db_helpers.connection, "cursor", lambda: _FakeCursorCM(12_345_678)
+        ):
+            self.assertEqual(
+                approx_count_or_exact(
+                    SafeContract, "history_safecontract", threshold=1000
+                ),
+                12_345_678,
+            )
+
+
+class TestActiveSafesTask(TestCase):
+    """The rewritten compute_active_safes_task: batched ERC20 probe + per-
+    window resilience."""
+
+    def test_erc20_active_safe_addresses_counted(self):
+        """A SafeContract that appears as `_from` of an ERC20 transfer
+        inside the window must show up in the active count, exercising the
+        new batched index-probe path."""
+        redis = get_redis()
+        redis.flushall()
+        safe = SafeContractFactory()
+        ERC20TransferFactory(_from=safe.address)
+
+        compute_active_safes_task.delay()
+
+        for window in ("7d", "30d", "90d"):
+            blob = redis.get(AnalyticsService.REDIS_ACTIVE_SAFES_PREFIX + window)
+            self.assertIsNotNone(blob, f"window {window} not cached")
+            payload = json.loads(blob)
+            self.assertGreaterEqual(payload["active_safes"], 1)
+
+    def test_distinct_across_all_three_legs(self):
+        """The same Safe touching all three legs (multisig / module / ERC20)
+        is counted once, not three times. Validates the set-union semantics."""
+        redis = get_redis()
+        redis.flushall()
+        safe = SafeContractFactory()
+        MultisigTransactionFactory(safe=safe.address)
+        ModuleTransactionFactory(safe=safe.address)
+        ERC20TransferFactory(_from=safe.address)
+
+        compute_active_safes_task.delay()
+
+        payload = json.loads(
+            redis.get(AnalyticsService.REDIS_ACTIVE_SAFES_PREFIX + "7d")
+        )
+        self.assertEqual(payload["active_safes"], 1)
+
+    def test_per_window_failure_isolated(self):
+        """If a single window's compute raises, the other windows still
+        land in Redis. Simulated by patching `_safes_active_in_window` to
+        raise only on the 30d cutoff."""
+        redis = get_redis()
+        redis.flushall()
+        SafeContractFactory()
+
+        real = _safes_active_in_window
+        call_count = {"n": 0}
+
+        def fake(cutoff):
+            call_count["n"] += 1
+            # Order is 7d, 30d, 90d — fail the middle window.
+            if call_count["n"] == 2:
+                raise RuntimeError("simulated planner timeout")
+            return real(cutoff)
+
+        with patch(
+            "safe_transaction_service.analytics.tasks._safes_active_in_window",
+            side_effect=fake,
+        ):
+            compute_active_safes_task.delay()
+
+        self.assertIsNotNone(
+            redis.get(AnalyticsService.REDIS_ACTIVE_SAFES_PREFIX + "7d")
+        )
+        self.assertIsNone(redis.get(AnalyticsService.REDIS_ACTIVE_SAFES_PREFIX + "30d"))
+        self.assertIsNotNone(
+            redis.get(AnalyticsService.REDIS_ACTIVE_SAFES_PREFIX + "90d")
+        )
+
+
+class TestActiveOwnersTask(TestCase):
+    """The rewritten compute_active_owners_task: two-step batched join."""
+
+    def test_counts_owners_of_executed_multisig_txs(self):
+        redis = get_redis()
+        redis.flushall()
+        MultisigConfirmationFactory()
+        MultisigConfirmationFactory()
+
+        compute_active_owners_task.delay()
+
+        for window in ("7d", "30d", "90d"):
+            blob = redis.get(AnalyticsService.REDIS_ACTIVE_OWNERS_PREFIX + window)
+            self.assertIsNotNone(blob, f"window {window} not cached")
+            payload = json.loads(blob)
+            self.assertGreaterEqual(payload["active_owners"], 1)
+
+    def test_batched_path_with_explicit_helper(self):
+        """Exercise `_active_owners_in_window` directly to make sure the
+        chunked join surfaces all distinct owners (not just those in the
+        first chunk)."""
+        from django.utils import timezone
+
+        # Two confirmations on two different multisig txs → two distinct
+        # owners. The function should return 2 regardless of how we slice
+        # the executed-tx IDs.
+        c1 = MultisigConfirmationFactory()
+        c2 = MultisigConfirmationFactory()
+        # Force a tiny batch size so we exercise the chunking branch even
+        # with this small fixture.
+        cutoff = timezone.now() - timezone.timedelta(days=30)
+        count = _active_owners_in_window(cutoff, batch_size=1)
+        self.assertGreaterEqual(count, 2)
+        # Sanity: both confirmations' owners are present in the underlying
+        # data even though the helper only returns a count.
+        self.assertNotEqual(c1.owner, c2.owner)
+
+
+class TestUpsertDailyMetric(TestCase):
+    """`_upsert_daily_metric` writes one row per day-window and re-runs it
+    idempotently. Tested directly (rather than through the Celery task) so
+    we can control the day window and seed factory data inside it without
+    racing the "yesterday-only" default."""
+
+    def test_writes_row_with_correct_counts(self):
+        from django.utils import timezone
+
+        safe = SafeContractFactory()
+        MultisigTransactionFactory(safe=safe.address, value=1500)
+        ModuleTransactionFactory(safe=safe.address)
+        ERC20TransferFactory(_from=safe.address)
+
+        # Window that wraps "now" so the factory rows fall inside it.
+        day_start = timezone.now() - timezone.timedelta(hours=1)
+        day_end = day_start + timezone.timedelta(days=1)
+        _upsert_daily_metric(day_start, day_end)
+
+        row = DailyMetric.objects.get(date=day_start.date())
+        self.assertGreaterEqual(row.multisig_txs_executed, 1)
+        self.assertGreaterEqual(row.module_txs, 1)
+        self.assertGreaterEqual(row.erc20_transfers, 1)
+        self.assertGreaterEqual(row.active_safes, 1)
+        self.assertEqual(int(row.native_value_wei), 1500)
+        self.assertIsNotNone(row.computed_at)
+
+    def test_idempotent_upsert(self):
+        from django.utils import timezone
+
+        safe = SafeContractFactory()
+        MultisigTransactionFactory(safe=safe.address, value=42)
+        day_start = timezone.now() - timezone.timedelta(hours=1)
+        day_end = day_start + timezone.timedelta(days=1)
+
+        _upsert_daily_metric(day_start, day_end)
+        first = DailyMetric.objects.get(date=day_start.date())
+        first_computed_at = first.computed_at
+
+        # Second call must update the same row, not create a new one.
+        _upsert_daily_metric(day_start, day_end)
+        self.assertEqual(DailyMetric.objects.count(), 1)
+        refreshed = DailyMetric.objects.get(date=day_start.date())
+        self.assertGreaterEqual(refreshed.computed_at, first_computed_at)
+
+
+class TestComputeDailyMetricsTask(TestCase):
+    """End-to-end task: the rolling-window cache refresh must populate the
+    same Redis keys the read path consumes, and a per-day failure must not
+    strand the rolling-window refresh that runs after the day loop."""
+
+    def test_refresh_active_window_caches_populates_redis(self):
+        redis = get_redis()
+        redis.flushall()
+
+        safe = SafeContractFactory()
+        MultisigTransactionFactory(safe=safe.address)
+
+        compute_daily_metrics_task(days_back=1)
+
+        for window in ("7d", "30d", "90d"):
+            blob = redis.get(AnalyticsService.REDIS_ACTIVE_SAFES_PREFIX + window)
+            self.assertIsNotNone(blob, f"active_safes {window} missing")
+            payload = json.loads(blob)
+            self.assertGreaterEqual(payload["active_safes"], 1)
+            self.assertEqual(payload["window"], window)
+
+    def test_per_day_failure_isolated(self):
+        """If `_upsert_daily_metric` raises for one day, the rolling-window
+        refresh still runs so the read path doesn't go cold."""
+        redis = get_redis()
+        redis.flushall()
+        SafeContractFactory()
+
+        with patch(
+            "safe_transaction_service.analytics.tasks._upsert_daily_metric",
+            side_effect=RuntimeError("simulated"),
+        ):
+            compute_daily_metrics_task(days_back=2)
+
+        # Day loop failed for every day; no DailyMetric rows.
+        self.assertEqual(DailyMetric.objects.count(), 0)
+        # But the rolling-window cache was refreshed regardless.
+        self.assertIsNotNone(
+            redis.get(AnalyticsService.REDIS_ACTIVE_SAFES_PREFIX + "7d")
+        )
+
+
+class TestBackfillDailyMetricsCommand(TestCase):
+    """`manage.py backfill_daily_metrics` should upsert one DailyMetric row
+    per day in the inclusive range, reusing the same task helper."""
+
+    def test_populates_date_range_inline(self):
+        from datetime import timedelta
+
+        from django.core.management import call_command
+        from django.utils import timezone
+
+        SafeContractFactory()
+        today = timezone.now().date()
+        # Three-day window ending yesterday so we don't collide with the
+        # incremental "yesterday-only" daily task semantics.
+        start = today - timedelta(days=3)
+        end = today - timedelta(days=1)
+
+        call_command(
+            "backfill_daily_metrics",
+            start=start.isoformat(),
+            end=end.isoformat(),
+            inline=True,
+        )
+
+        self.assertEqual(DailyMetric.objects.count(), 3)
+        for offset in range(3):
+            d = start + timedelta(days=offset)
+            self.assertTrue(
+                DailyMetric.objects.filter(date=d).exists(),
+                f"missing DailyMetric for {d}",
+            )
+
+    def test_populates_date_range_celery_eager(self):
+        """Default (no --inline) dispatches one Celery shard per day.
+        Under CELERY_ALWAYS_EAGER the dispatch runs shards inline and
+        returns the summary dict; we just check the row count lands."""
+        from datetime import timedelta
+
+        from django.core.management import call_command
+        from django.utils import timezone
+
+        SafeContractFactory()
+        today = timezone.now().date()
+        start = today - timedelta(days=3)
+        end = today - timedelta(days=1)
+
+        call_command(
+            "backfill_daily_metrics",
+            start=start.isoformat(),
+            end=end.isoformat(),
+        )
+
+        self.assertEqual(DailyMetric.objects.count(), 3)
+
+
+class TestDailyRollupPopulators(TestCase):
+    """One test per narrow rollup populator. Asserts the populator writes
+    the expected (date, key) rows AND that a second call is idempotent —
+    `ON CONFLICT DO UPDATE` / `ignore_conflicts=True` semantics.
+    """
+
+    def setUp(self):
+        super().setUp()
+        from django.utils import timezone
+
+        self.day_start = timezone.now() - timezone.timedelta(hours=1)
+        self.day_end = self.day_start + timezone.timedelta(days=1)
+        self.date_value = self.day_start.date()
+
+    def test_compute_daily_token_volume(self):
+        from eth_account import Account
+
+        from safe_transaction_service.analytics.models import DailyTokenVolume
+        from safe_transaction_service.analytics.tasks import (
+            _compute_daily_token_volume,
+        )
+
+        token = Account.create().address
+        ERC20TransferFactory(address=token, value=100)
+        ERC20TransferFactory(address=token, value=250)
+
+        _compute_daily_token_volume(self.day_start, self.day_end)
+        row = DailyTokenVolume.objects.get(date=self.date_value, token_address=token)
+        self.assertEqual(row.transfer_count, 2)
+        self.assertEqual(int(row.transfer_value), 350)
+
+        # Rerun should leave a single row with the same totals — ON CONFLICT
+        # DO UPDATE.
+        _compute_daily_token_volume(self.day_start, self.day_end)
+        self.assertEqual(
+            DailyTokenVolume.objects.filter(
+                date=self.date_value, token_address=token
+            ).count(),
+            1,
+        )
+
+    def test_compute_daily_active_safes(self):
+        from safe_transaction_service.analytics.models import DailyActiveSafe
+        from safe_transaction_service.analytics.tasks import (
+            _compute_daily_active_safes,
+        )
+
+        safe = SafeContractFactory()
+        MultisigTransactionFactory(safe=safe.address)
+
+        _compute_daily_active_safes(self.day_start, self.day_end)
+        self.assertEqual(
+            DailyActiveSafe.objects.filter(date=self.date_value).count(), 1
+        )
+
+        # Rerun is a no-op via ignore_conflicts=True (membership table).
+        _compute_daily_active_safes(self.day_start, self.day_end)
+        self.assertEqual(
+            DailyActiveSafe.objects.filter(date=self.date_value).count(), 1
+        )
+
+    def test_compute_daily_safe_app_txs(self):
+        from safe_transaction_service.analytics.models import DailySafeAppTx
+        from safe_transaction_service.analytics.tasks import (
+            _compute_daily_safe_app_txs,
+        )
+
+        origin = {"url": "https://example.com", "name": "MyDapp"}
+        MultisigTransactionFactory(origin=origin)
+        MultisigTransactionFactory(origin=origin)
+
+        _compute_daily_safe_app_txs(self.day_start, self.day_end)
+        row = DailySafeAppTx.objects.get(date=self.date_value, origin_name="MyDapp")
+        self.assertEqual(row.tx_count, 2)
+        # origin_url is denormalised onto the rollup so the read path
+        # doesn't have to re-touch history_multisigtransaction.
+        self.assertEqual(row.origin_url, "https://example.com")
+
+        _compute_daily_safe_app_txs(self.day_start, self.day_end)
+        self.assertEqual(
+            DailySafeAppTx.objects.filter(
+                date=self.date_value, origin_name="MyDapp"
+            ).count(),
+            1,
+        )
+
+    def test_compute_daily_safe_app_txs_short_circuits_when_no_origin_data(self):
+        """On chains with zero multisig txs carrying origin metadata
+        (BASE today), the populator must return immediately without
+        touching the 3-way join. The probe is bounded by `LIMIT 1` —
+        no need to actually count the chain's origin rows."""
+        from safe_transaction_service.analytics.models import DailySafeAppTx
+        from safe_transaction_service.analytics.tasks import (
+            _compute_daily_safe_app_txs,
+        )
+
+        # Seed multisig txs with NO origin name — the probe should see
+        # nothing and bail before doing the heavy join.
+        MultisigTransactionFactory(origin={})
+        MultisigTransactionFactory(origin={"url": "https://x"})  # no name
+
+        result = _compute_daily_safe_app_txs(self.day_start, self.day_end)
+        self.assertEqual(result, 0)
+        self.assertEqual(DailySafeAppTx.objects.filter(date=self.date_value).count(), 0)
+
+    def test_compute_daily_safe_creations(self):
+        from safe_transaction_service.analytics.models import (
+            DailySafeCreation,
+        )
+        from safe_transaction_service.analytics.tasks import (
+            _compute_daily_safe_creations,
+        )
+
+        SafeContractFactory()
+        SafeContractFactory()
+
+        _compute_daily_safe_creations(self.day_start, self.day_end)
+        row = DailySafeCreation.objects.get(date=self.date_value)
+        self.assertEqual(row.count, 2)
+
+        _compute_daily_safe_creations(self.day_start, self.day_end)
+        self.assertEqual(
+            DailySafeCreation.objects.filter(date=self.date_value).count(), 1
+        )
+
+    def test_compute_daily_tx_volume(self):
+        from safe_transaction_service.analytics.tasks import (
+            _compute_daily_tx_volume,
+        )
+
+        # Three proposed multisig txs, one with two confirmations and one
+        # with one confirmation — third has none.
+        tx_with_two = MultisigTransactionFactory()
+        tx_with_one = MultisigTransactionFactory()
+        MultisigTransactionFactory()
+        MultisigConfirmationFactory(multisig_transaction=tx_with_two)
+        MultisigConfirmationFactory(multisig_transaction=tx_with_two)
+        MultisigConfirmationFactory(multisig_transaction=tx_with_one)
+
+        _compute_daily_tx_volume(self.day_start, self.day_end)
+        row = DailyMetric.objects.get(date=self.date_value)
+        self.assertEqual(row.multisig_txs_proposed, 3)
+        self.assertEqual(row.confirmations_count, 3)
+        self.assertEqual(row.confirmed_tx_count, 2)
+        self.assertIsNotNone(row.computed_at)
+
+        # Idempotent — re-run yields the same counts, one row.
+        _compute_daily_tx_volume(self.day_start, self.day_end)
+        self.assertEqual(DailyMetric.objects.filter(date=self.date_value).count(), 1)
+        refreshed = DailyMetric.objects.get(date=self.date_value)
+        self.assertEqual(refreshed.multisig_txs_proposed, 3)
+        self.assertEqual(refreshed.confirmations_count, 3)
+        self.assertEqual(refreshed.confirmed_tx_count, 2)
+
+    def test_compute_daily_tx_volume_empty_window(self):
+        """No data in the window → row inserted with zeros (caller can
+        sum it safely)."""
+        from safe_transaction_service.analytics.tasks import (
+            _compute_daily_tx_volume,
+        )
+
+        _compute_daily_tx_volume(self.day_start, self.day_end)
+        row = DailyMetric.objects.get(date=self.date_value)
+        self.assertEqual(row.multisig_txs_proposed, 0)
+        self.assertEqual(row.confirmations_count, 0)
+        self.assertEqual(row.confirmed_tx_count, 0)
+
+    def test_compute_daily_tx_volume_preserves_core_columns(self):
+        """When `_compute_daily_metric_core` has already written the row,
+        the tx-volume upsert must update ONLY the three new columns and
+        leave the executed-side counts alone (ON CONFLICT clause is
+        explicit about which fields to overwrite)."""
+        from safe_transaction_service.analytics.tasks import (
+            _compute_daily_tx_volume,
+        )
+
+        DailyMetric.objects.create(
+            date=self.date_value,
+            multisig_txs_executed=7,
+            module_txs=3,
+            erc20_transfers=11,
+            native_value_wei=12345,
+            active_safes=5,
+            active_owners=4,
+            new_safes=2,
+            computed_at=self.day_start,
+        )
+        MultisigTransactionFactory()
+
+        _compute_daily_tx_volume(self.day_start, self.day_end)
+        row = DailyMetric.objects.get(date=self.date_value)
+        self.assertEqual(row.multisig_txs_proposed, 1)
+        # Executed-side columns untouched.
+        self.assertEqual(row.multisig_txs_executed, 7)
+        self.assertEqual(row.module_txs, 3)
+        self.assertEqual(row.erc20_transfers, 11)
+        self.assertEqual(int(row.native_value_wei), 12345)
+        self.assertEqual(row.active_safes, 5)
+        self.assertEqual(row.active_owners, 4)
+        self.assertEqual(row.new_safes, 2)
+
+
+class TestUpsertDailyMetricFullStack(TestCase):
+    """The 5-step `_upsert_daily_metric` populates DailyMetric + all four
+    rollups inside a single call. Failure of any one rollup must not
+    strand the others or the DailyMetric row (per-populator try/except)."""
+
+    def test_writes_all_rollups(self):
+        from datetime import timedelta
+
+        from django.utils import timezone
+
+        from safe_transaction_service.analytics.models import (
+            DailyActiveSafe,
+            DailySafeAppTx,
+            DailySafeCreation,
+            DailyTokenVolume,
+        )
+
+        safe = SafeContractFactory()
+        MultisigConfirmationFactory(
+            multisig_transaction=MultisigTransactionFactory(
+                safe=safe.address, origin={"url": "u", "name": "App"}
+            )
+        )
+        ERC20TransferFactory()
+
+        day_start = timezone.now() - timedelta(hours=1)
+        day_end = day_start + timedelta(days=1)
+        _upsert_daily_metric(day_start, day_end)
+
+        d = day_start.date()
+        self.assertTrue(DailyMetric.objects.filter(date=d).exists())
+        self.assertTrue(DailyTokenVolume.objects.filter(date=d).exists())
+        self.assertTrue(DailyActiveSafe.objects.filter(date=d).exists())
+        self.assertTrue(DailyActiveOwner.objects.filter(date=d).exists())
+        self.assertTrue(DailySafeAppTx.objects.filter(date=d).exists())
+        self.assertTrue(DailySafeCreation.objects.filter(date=d).exists())
+
+    def test_one_rollup_failure_isolated(self):
+        """Patch one populator to raise; the others (and the DailyMetric
+        row) must still land."""
+        from datetime import timedelta
+
+        from django.utils import timezone
+
+        from safe_transaction_service.analytics.models import (
+            DailySafeCreation,
+        )
+
+        safe = SafeContractFactory()
+        MultisigTransactionFactory(safe=safe.address)
+
+        day_start = timezone.now() - timedelta(hours=1)
+        day_end = day_start + timedelta(days=1)
+
+        with patch(
+            "safe_transaction_service.analytics.tasks._compute_daily_active_safes",
+            side_effect=RuntimeError("boom"),
+        ):
+            _upsert_daily_metric(day_start, day_end)
+
+        d = day_start.date()
+        self.assertTrue(DailyMetric.objects.filter(date=d).exists())
+        # The non-failing rollups still landed.
+        self.assertTrue(DailySafeCreation.objects.filter(date=d).exists())
+
+
+class TestNativeBalanceShards(TestCase):
+    """Sharded native-balance compute under eager mode must match the
+    sequential reference implementation."""
+
+    def test_chord_matches_sequential(self):
+        from celery import chord
+
+        from safe_transaction_service.analytics.tasks import (
+            _calculate_native_balances_from_db_sequential,
+        )
+        from safe_transaction_service.analytics.tasks_shards import (
+            HEX_PREFIXES,
+            compute_native_balance_shard,
+            reduce_native_balance_shards,
+        )
+
+        for _ in range(3):
+            safe = SafeContractFactory()
+            InternalTxFactory(
+                to=safe.address,
+                value=1_000,
+                call_type=0,
+                error=None,
+            )
+
+        seq_balance, seq_count = _calculate_native_balances_from_db_sequential()
+        # Eager mode runs the chord inline; bypass the fire-and-forget
+        # `dispatch_tvl_chord` so we can read the reduced result back here.
+        reduced = (
+            chord(
+                (compute_native_balance_shard.s(p) for p in HEX_PREFIXES),
+                reduce_native_balance_shards.s(),
+            )
+            .apply_async()
+            .get()
+        )
+        self.assertEqual(seq_balance, reduced["balance_wei"])
+        self.assertEqual(seq_count, reduced["safes_with_balance"])
+        self.assertGreater(reduced["balance_wei"], 0)
+        self.assertEqual(reduced["safes_with_balance"], 3)
+
+    def test_shards_partition_address_space(self):
+        """Every Safe is hit by exactly one shard. Sum of shard counts ==
+        total safes with balance."""
+        from safe_transaction_service.analytics.tasks_shards import (
+            HEX_PREFIXES,
+            compute_native_balance_shard,
+        )
+
+        # Seed a small but predictable set.
+        for _ in range(4):
+            safe = SafeContractFactory()
+            InternalTxFactory(
+                to=safe.address,
+                value=500,
+                call_type=0,
+                error=None,
+            )
+
+        total = 0
+        for prefix in HEX_PREFIXES:
+            shard = compute_native_balance_shard(prefix)
+            total += shard["safes_with_balance"]
+        # Each seeded Safe lands in exactly one shard.
+        self.assertEqual(total, 4)
+
+
+class TestKeysetPagination(TestCase):
+    """`_iter_safe_addresses_keyset` is the load-bearing replacement for
+    the old OFFSET/LIMIT loop. The bug it fixes is silent (correctness
+    holds, performance collapses on multi-million-Safe chains), so the
+    unit guarantee that survives is: every Safe is yielded exactly once,
+    in PK order, regardless of how small the batch is."""
+
+    def test_yields_every_address_exactly_once(self):
+        from safe_transaction_service.analytics.tasks import (
+            _iter_safe_addresses_keyset,
+        )
+
+        # Seed 7 Safes; iterate with batch_size=2 to force `address__gt`
+        # boundary crossings and exercise the keyset cursor explicitly.
+        for _ in range(7):
+            SafeContractFactory()
+        expected = list(
+            SafeContract.objects.values_list("address", flat=True).order_by("pk")
+        )
+
+        seen = []
+        for chunk in _iter_safe_addresses_keyset(batch_size=2):
+            self.assertLessEqual(len(chunk), 2)
+            seen.extend(chunk)
+
+        self.assertEqual(seen, expected)
+
+    def test_empty_safe_contracts_terminates(self):
+        from safe_transaction_service.analytics.tasks import (
+            _iter_safe_addresses_keyset,
+        )
+
+        self.assertEqual(list(_iter_safe_addresses_keyset(batch_size=10)), [])
+
+
+class TestErc20ActiveSafeAddrsBetween(TestCase):
+    """The bounded-window helper used to issue ~200 batched EXISTS probes
+    per call; it now resolves to a single JOIN over the day's transfers.
+    Behaviour contract: returns the set of Safe addresses with any
+    ERC20 transfer (_from OR to) strictly inside `[start, end)`."""
+
+    def test_includes_safes_with_transfer_inside_window(self):
+        from django.utils import timezone
+
+        from safe_transaction_service.analytics.tasks import (
+            _erc20_active_safe_addrs_between,
+        )
+
+        start = timezone.now() - timezone.timedelta(hours=1)
+        end = start + timezone.timedelta(days=1)
+
+        safe_in = SafeContractFactory()
+        ERC20TransferFactory(to=safe_in.address)
+
+        result = _erc20_active_safe_addrs_between(start, end)
+        self.assertIn(safe_in.address.lower(), {a.lower() for a in result})
+
+    def test_excludes_safes_with_no_transfers(self):
+        from django.utils import timezone
+
+        from safe_transaction_service.analytics.tasks import (
+            _erc20_active_safe_addrs_between,
+        )
+
+        start = timezone.now() - timezone.timedelta(hours=1)
+        end = start + timezone.timedelta(days=1)
+
+        SafeContractFactory()  # no transfers — must not appear
+        safe_in = SafeContractFactory()
+        ERC20TransferFactory(_from=safe_in.address)
+
+        result = {a.lower() for a in _erc20_active_safe_addrs_between(start, end)}
+        self.assertEqual(len(result), 1)
+        self.assertIn(safe_in.address.lower(), result)
+
+    def test_excludes_non_safe_addresses(self):
+        """Transfers whose endpoints are not SafeContracts must not be
+        returned — the JOIN against `history_safecontract` is what
+        enforces this."""
+        from django.utils import timezone
+
+        from safe_transaction_service.analytics.tasks import (
+            _erc20_active_safe_addrs_between,
+        )
+
+        start = timezone.now() - timezone.timedelta(hours=1)
+        end = start + timezone.timedelta(days=1)
+
+        # Transfer between two non-Safe addresses: the JOIN drops it.
+        ERC20TransferFactory()
+
+        self.assertEqual(_erc20_active_safe_addrs_between(start, end), set())
+
+
+class TestDailyActiveOwnersPopulator(TestCase):
+    """`_compute_daily_active_owners` writes one row per (date, owner)
+    where the owner confirmed any multisig tx whose tx block.timestamp
+    landed in the day window. Mirror of `_compute_daily_active_safes`
+    — single SQL, idempotent via `ON CONFLICT DO NOTHING`."""
+
+    def setUp(self):
+        super().setUp()
+        from django.utils import timezone
+
+        self.day_start = timezone.now() - timezone.timedelta(hours=1)
+        self.day_end = self.day_start + timezone.timedelta(days=1)
+        self.date_value = self.day_start.date()
+
+    def test_writes_one_row_per_distinct_confirming_owner(self):
+        from safe_transaction_service.analytics.tasks import (
+            _compute_daily_active_owners,
+        )
+
+        c1 = MultisigConfirmationFactory()
+        c2 = MultisigConfirmationFactory()
+        # Sanity: factory uses fresh owner per confirmation.
+        self.assertNotEqual(c1.owner, c2.owner)
+
+        _compute_daily_active_owners(self.day_start, self.day_end)
+        self.assertEqual(
+            DailyActiveOwner.objects.filter(date=self.date_value).count(), 2
+        )
+
+    def test_idempotent_on_rerun(self):
+        """`ON CONFLICT DO NOTHING` keeps the table single-row-per-
+        (date, owner) on a second invocation."""
+        from safe_transaction_service.analytics.tasks import (
+            _compute_daily_active_owners,
+        )
+
+        MultisigConfirmationFactory()
+
+        _compute_daily_active_owners(self.day_start, self.day_end)
+        first_count = DailyActiveOwner.objects.filter(date=self.date_value).count()
+        self.assertGreaterEqual(first_count, 1)
+
+        _compute_daily_active_owners(self.day_start, self.day_end)
+        self.assertEqual(
+            DailyActiveOwner.objects.filter(date=self.date_value).count(),
+            first_count,
+        )
+
+    def test_distinct_owners_counted_once(self):
+        """A single owner confirming on two multisig txs in the window
+        appears once — distinct semantic, same shape as DailyActiveSafe."""
+        from safe_transaction_service.analytics.tasks import (
+            _compute_daily_active_owners,
+        )
+
+        c1 = MultisigConfirmationFactory()
+        # Second confirmation from the same owner on a different multisig
+        # tx must NOT create a duplicate row.
+        MultisigConfirmationFactory(owner=c1.owner)
+
+        _compute_daily_active_owners(self.day_start, self.day_end)
+        self.assertEqual(
+            DailyActiveOwner.objects.filter(
+                date=self.date_value, owner_address=c1.owner
+            ).count(),
+            1,
+        )
+
+
+class TestSnapshotWritingTasks(TestCase):
+    """Each of the four current-state task functions must persist to
+    `analytics_analyticssnapshot` rather than Redis after the Part 2
+    cut (see `flickering-honking-wand.md`)."""
+
+    def test_compute_safe_segments_task_writes_snapshot(self):
+        from eth_account import Account
+
+        from safe_transaction_service.analytics.tasks import (
+            compute_safe_segments_task,
+        )
+
+        redis = get_redis()
+        redis.flushall()
+        AnalyticsSnapshot.objects.all().delete()
+        # Personal Safe (1 owner) + Team Safe (3 owners).
+        SafeStatusFactory(owners=[Account.create().address], threshold=1)
+        SafeStatusFactory(
+            owners=[Account.create().address for _ in range(3)], threshold=2
+        )
+
+        compute_safe_segments_task.delay()
+
+        snap = AnalyticsSnapshot.objects.get(name="safe_segments")
+        self.assertEqual(snap.payload["personal"], 1)
+        self.assertEqual(snap.payload["team"], 1)
+        self.assertIsNotNone(snap.computed_at)
+        # Legacy Redis key must not be written.
+        self.assertIsNone(redis.get(AnalyticsService.REDIS_SAFE_SEGMENTS))
+
+    def test_compute_tvl_task_writes_snapshot(self):
+        from safe_transaction_service.analytics.tasks import compute_tvl_task
+
+        redis = get_redis()
+        redis.flushall()
+        AnalyticsSnapshot.objects.all().delete()
+        safe = SafeContractFactory()
+        InternalTxFactory(to=safe.address, value=1_000_000, call_type=0, error=None)
+
+        compute_tvl_task.delay()
+
+        snap = AnalyticsSnapshot.objects.get(name="tvl")
+        self.assertIn("native_balance_wei", snap.payload)
+        self.assertIn("top_tokens", snap.payload)
+        self.assertIsNotNone(snap.computed_at)
+        # Legacy Redis key must not be written.
+        self.assertIsNone(redis.get(AnalyticsService.REDIS_TVL))
+
+    def test_compute_tvl_task_snapshot_lands_when_balance_calc_fails(self):
+        """The phase-1 placeholder snapshot must persist even when the chord
+        callback raises during the ERC20 aggregation — endpoint should
+        return a coherent zero-valued payload instead of all-null."""
+        from safe_transaction_service.analytics.tasks import compute_tvl_task
+
+        AnalyticsSnapshot.objects.all().delete()
+        SafeContractFactory()
+
+        # `finalize_tvl_snapshot` runs in the chord callback after reduce
+        # and is where the heavy ERC20 aggregates + final snapshot write
+        # happen. Patching it to raise leaves the phase-1 placeholder in
+        # place — same end-user contract as before.
+        with patch(
+            "safe_transaction_service.analytics.tasks_shards.finalize_tvl_snapshot.run",
+            side_effect=RuntimeError("simulated ERC20 aggregate failure"),
+        ):
+            compute_tvl_task.delay()
+
+        snap = AnalyticsSnapshot.objects.get(name="tvl")
+        self.assertEqual(snap.payload["native_balance_wei"], "0")
+        self.assertEqual(snap.payload["total_safes_with_balance"], 0)
+        self.assertEqual(snap.payload["erc20_token_count"], 0)
+        self.assertEqual(snap.payload["top_tokens"], [])
+        self.assertIsNotNone(snap.computed_at)

--- a/safe_transaction_service/analytics/tests/test_views_v2.py
+++ b/safe_transaction_service/analytics/tests/test_views_v2.py
@@ -1,31 +1,61 @@
+import json
+from unittest.mock import patch
+
 from django.contrib.auth.models import User
 from django.urls import reverse
 
 from rest_framework import status
 from rest_framework.authtoken.models import Token
 from rest_framework.test import APITestCase
-from safe_eth.safe.tests.safe_test_case import SafeTestCaseMixin
 
-from safe_transaction_service.history.tests.factories import MultisigTransactionFactory
+from safe_transaction_service.analytics.models import AnalyticsSnapshot
+from safe_transaction_service.analytics.services.analytics_service import (
+    AnalyticsService,
+)
+from safe_transaction_service.analytics.tasks import (
+    compute_active_owners_task,
+    compute_active_safes_task,
+    compute_daily_metrics_task,
+    compute_safe_segments_task,
+    compute_summary_task,
+    compute_tvl_task,
+    get_transactions_per_safe_app_task,
+)
+from safe_transaction_service.history.tests.factories import (
+    ERC20TransferFactory,
+    ERC721TransferFactory,
+    InternalTxFactory,
+    ModuleTransactionFactory,
+    MultisigConfirmationFactory,
+    MultisigTransactionFactory,
+    SafeContractFactory,
+    SafeStatusFactory,
+)
+from safe_transaction_service.utils.redis import get_redis
 
-from ...utils.redis import get_redis
-from ..tasks import get_transactions_per_safe_app_task
+
+class AnalyticsTestMixin:
+    """Common setup for analytics test classes."""
+
+    def setUp(self):
+        super().setUp()
+        self.redis = get_redis()
+        self.redis.flushall()
+        self.user, _ = User.objects.get_or_create(username="test", password="12345")
+        self.token, _ = Token.objects.get_or_create(user=self.user)
+        self.auth_header = {"HTTP_AUTHORIZATION": "Token " + self.token.key}
 
 
-class TestViewsV2(SafeTestCaseMixin, APITestCase):
+class TestViewsV2(AnalyticsTestMixin, APITestCase):
     def test_analytics_multisig_txs_by_origin_view(self):
-        redis = get_redis()
-        redis.flushall()
         response = self.client.get(
             reverse("v2:analytics:analytics-multisig-txs-by-origin")
         )
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
-        user, _ = User.objects.get_or_create(username="test", password="12345")
-        token, _ = Token.objects.get_or_create(user=user)
-        header = {"HTTP_AUTHORIZATION": "Token " + token.key}
         response = self.client.get(
-            reverse("v2:analytics:analytics-multisig-txs-by-origin"), **header
+            reverse("v2:analytics:analytics-multisig-txs-by-origin"),
+            **self.auth_header,
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data, [])
@@ -34,10 +64,10 @@ class TestViewsV2(SafeTestCaseMixin, APITestCase):
         origin_2 = {"url": "https://example2.com", "name": "SafeApp2"}
 
         MultisigTransactionFactory(origin=origin_1)
-        # Execute the periodic task
         get_transactions_per_safe_app_task()
         response = self.client.get(
-            reverse("v2:analytics:analytics-multisig-txs-by-origin"), **header
+            reverse("v2:analytics:analytics-multisig-txs-by-origin"),
+            **self.auth_header,
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         expected = [
@@ -55,11 +85,11 @@ class TestViewsV2(SafeTestCaseMixin, APITestCase):
         for _ in range(3):
             MultisigTransactionFactory(origin=origin_2)
 
-        # Execute the periodic task
         get_transactions_per_safe_app_task()
 
         response = self.client.get(
-            reverse("v2:analytics:analytics-multisig-txs-by-origin"), **header
+            reverse("v2:analytics:analytics-multisig-txs-by-origin"),
+            **self.auth_header,
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         expected = [
@@ -85,11 +115,10 @@ class TestViewsV2(SafeTestCaseMixin, APITestCase):
         for _ in range(3):
             MultisigTransactionFactory(origin=origin_1)
 
-        # Execute the periodic task
         get_transactions_per_safe_app_task()
-        # Check sorting by the biggest
         response = self.client.get(
-            reverse("v2:analytics:analytics-multisig-txs-by-origin"), **header
+            reverse("v2:analytics:analytics-multisig-txs-by-origin"),
+            **self.auth_header,
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         expected = [
@@ -111,3 +140,967 @@ class TestViewsV2(SafeTestCaseMixin, APITestCase):
             },
         ]
         self.assertEqual(response.data, expected)
+
+
+class TestSummaryView(AnalyticsTestMixin, APITestCase):
+    def test_auth_required(self):
+        response = self.client.get(reverse("v2:analytics:analytics-summary"))
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    @patch(
+        "safe_transaction_service.utils.ethereum.get_chain_id",
+        return_value=84532,
+    )
+    def test_summary_empty(self, mock_chain_id):
+        response = self.client.get(
+            reverse("v2:analytics:analytics-summary"), **self.auth_header
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.data
+        self.assertEqual(data["total_safes"], 0)
+        self.assertEqual(data["total_multisig_txs"], 0)
+        self.assertEqual(data["total_module_txs"], 0)
+        self.assertEqual(data["total_erc20_transfers"], 0)
+        self.assertEqual(data["total_erc721_transfers"], 0)
+        self.assertIsNone(data["first_safe_created"])
+        self.assertIsNone(data["last_safe_created"])
+        self.assertEqual(data["chain_id"], 84532)
+
+    @patch(
+        "safe_transaction_service.utils.ethereum.get_chain_id",
+        return_value=84532,
+    )
+    def test_summary_with_data(self, mock_chain_id):
+        SafeContractFactory()
+        SafeContractFactory()
+        MultisigTransactionFactory()
+        ModuleTransactionFactory()
+        ERC20TransferFactory()
+        ERC721TransferFactory()
+
+        # Pre-warm the snapshot — the view no longer blocks on compute.
+        # In production the daily cron warms this; in tests we run the
+        # task synchronously instead.
+        compute_summary_task()
+
+        response = self.client.get(
+            reverse("v2:analytics:analytics-summary"), **self.auth_header
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.data
+        self.assertEqual(data["total_safes"], 2)
+        self.assertEqual(data["total_multisig_txs"], 1)
+        self.assertEqual(data["total_module_txs"], 1)
+        self.assertEqual(data["total_erc20_transfers"], 1)
+        self.assertEqual(data["total_erc721_transfers"], 1)
+        self.assertIsNotNone(data["first_safe_created"])
+        self.assertIsNotNone(data["last_safe_created"])
+
+
+class TestActiveSafesView(AnalyticsTestMixin, APITestCase):
+    def test_auth_required(self):
+        response = self.client.get(reverse("v2:analytics:analytics-active-safes"))
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_invalid_window(self):
+        response = self.client.get(
+            reverse("v2:analytics:analytics-active-safes"),
+            {"window": "5d"},
+            **self.auth_header,
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_empty_cache(self):
+        response = self.client.get(
+            reverse("v2:analytics:analytics-active-safes"),
+            {"window": "30d"},
+            **self.auth_header,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["active_safes"], 0)
+
+    def test_with_cached_data(self):
+        safe = SafeContractFactory()
+        MultisigTransactionFactory(safe=safe.address)
+
+        compute_active_safes_task()
+
+        response = self.client.get(
+            reverse("v2:analytics:analytics-active-safes"),
+            {"window": "30d"},
+            **self.auth_header,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertGreaterEqual(response.data["active_safes"], 1)
+        self.assertIsNotNone(response.data["computed_at"])
+
+
+class TestSafeCreationsView(AnalyticsTestMixin, APITestCase):
+    def test_auth_required(self):
+        response = self.client.get(reverse("v2:analytics:analytics-safe-creations"))
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_invalid_interval(self):
+        response = self.client.get(
+            reverse("v2:analytics:analytics-safe-creations"),
+            {"interval": "hour"},
+            **self.auth_header,
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_empty(self):
+        response = self.client.get(
+            reverse("v2:analytics:analytics-safe-creations"),
+            {"interval": "day"},
+            **self.auth_header,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, [])
+
+    def test_with_data(self):
+        SafeContractFactory()
+        SafeContractFactory()
+
+        response = self.client.get(
+            reverse("v2:analytics:analytics-safe-creations"),
+            {"interval": "day"},
+            **self.auth_header,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertGreater(len(response.data), 0)
+        for entry in response.data:
+            self.assertIn("period", entry)
+            self.assertIn("count", entry)
+
+
+class TestActiveOwnersView(AnalyticsTestMixin, APITestCase):
+    def test_auth_required(self):
+        response = self.client.get(reverse("v2:analytics:analytics-active-owners"))
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_invalid_window(self):
+        response = self.client.get(
+            reverse("v2:analytics:analytics-active-owners"),
+            {"window": "1y"},
+            **self.auth_header,
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_with_cached_data(self):
+        MultisigConfirmationFactory()
+
+        compute_active_owners_task()
+
+        response = self.client.get(
+            reverse("v2:analytics:analytics-active-owners"),
+            {"window": "30d"},
+            **self.auth_header,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertGreaterEqual(response.data["active_owners"], 1)
+        self.assertIsNotNone(response.data["computed_at"])
+
+
+class TestTxVolumeView(AnalyticsTestMixin, APITestCase):
+    def test_auth_required(self):
+        response = self.client.get(reverse("v2:analytics:analytics-tx-volume"))
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_empty(self):
+        response = self.client.get(
+            reverse("v2:analytics:analytics-tx-volume"),
+            {"window": "30d"},
+            **self.auth_header,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.data
+        self.assertEqual(data["total_multisig_txs"], 0)
+        self.assertEqual(data["executed_multisig_txs"], 0)
+        self.assertEqual(data["module_txs"], 0)
+        self.assertEqual(data["total_value_wei"], "0")
+
+    def test_with_data(self):
+        """The view reads from the DailyMetric rollup. Today's row is
+        excluded (`date__lt=today`) because today isn't a completed day
+        yet — same semantics as `safe-creations` and `token-volume`.
+
+        Seed a row at today-1 directly; the populator's correctness
+        against factory data is covered by `test_compute_daily_tx_volume`
+        in `test_tasks.py`.
+        """
+        from datetime import timedelta
+
+        from django.utils import timezone
+
+        from safe_transaction_service.analytics.models import DailyMetric
+
+        DailyMetric.objects.create(
+            date=timezone.now().date() - timedelta(days=1),
+            multisig_txs_proposed=2,
+            multisig_txs_executed=2,
+            module_txs=1,
+            native_value_wei=3000,
+            confirmations_count=4,
+            confirmed_tx_count=2,
+            computed_at=timezone.now(),
+        )
+
+        response = self.client.get(
+            reverse("v2:analytics:analytics-tx-volume"),
+            {"window": "30d"},
+            **self.auth_header,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.data
+        self.assertEqual(data["total_multisig_txs"], 2)
+        self.assertEqual(data["executed_multisig_txs"], 2)
+        self.assertEqual(data["module_txs"], 1)
+        self.assertEqual(data["total_value_wei"], "3000")
+        self.assertEqual(data["avg_confirmations"], 2.0)
+        self.assertEqual(data.get("source"), "daily_metric")
+        self.assertEqual(data["coverage_days"], 1)
+
+
+class TestSafeSegmentsView(AnalyticsTestMixin, APITestCase):
+    def test_auth_required(self):
+        response = self.client.get(reverse("v2:analytics:analytics-safe-segments"))
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_empty_cache(self):
+        response = self.client.get(
+            reverse("v2:analytics:analytics-safe-segments"), **self.auth_header
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.data
+        self.assertEqual(data["personal"], 0)
+        self.assertEqual(data["team"], 0)
+        self.assertEqual(data["enterprise"], 0)
+
+    def test_with_cached_data(self):
+        from eth_account import Account
+
+        # Personal Safe (1 owner)
+        SafeStatusFactory(owners=[Account.create().address], threshold=1)
+        # Team Safe (3 owners)
+        SafeStatusFactory(
+            owners=[Account.create().address for _ in range(3)], threshold=2
+        )
+
+        compute_safe_segments_task()
+
+        response = self.client.get(
+            reverse("v2:analytics:analytics-safe-segments"), **self.auth_header
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.data
+        self.assertEqual(data["personal"], 1)
+        self.assertEqual(data["team"], 1)
+        self.assertEqual(data["enterprise"], 0)
+        self.assertIsNotNone(data["computed_at"])
+
+
+class TestTvlView(AnalyticsTestMixin, APITestCase):
+    def test_auth_required(self):
+        response = self.client.get(reverse("v2:analytics:analytics-tvl"))
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_empty_cache(self):
+        response = self.client.get(
+            reverse("v2:analytics:analytics-tvl"), **self.auth_header
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.data
+        self.assertEqual(data["total_safes_with_balance"], 0)
+        self.assertEqual(data["native_balance_wei"], "0")
+        self.assertEqual(data["erc20_token_count"], 0)
+        self.assertEqual(data["top_tokens"], [])
+
+    def test_with_cached_data(self):
+        safe = SafeContractFactory()
+        InternalTxFactory(to=safe.address, value=1000000)
+
+        compute_tvl_task()
+
+        response = self.client.get(
+            reverse("v2:analytics:analytics-tvl"), **self.auth_header
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.data
+        self.assertIsNotNone(data["computed_at"])
+
+
+class TestTokenVolumeView(AnalyticsTestMixin, APITestCase):
+    def test_auth_required(self):
+        response = self.client.get(reverse("v2:analytics:analytics-token-volume"))
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_empty(self):
+        response = self.client.get(
+            reverse("v2:analytics:analytics-token-volume"),
+            {"window": "30d"},
+            **self.auth_header,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.data
+        self.assertEqual(data["total_erc20_transfers"], 0)
+        self.assertEqual(data["unique_tokens"], 0)
+        self.assertEqual(data["top_tokens"], [])
+
+    def test_with_data(self):
+        from eth_account import Account
+
+        token_address = Account.create().address
+        ERC20TransferFactory(address=token_address, value=100)
+        ERC20TransferFactory(address=token_address, value=200)
+
+        response = self.client.get(
+            reverse("v2:analytics:analytics-token-volume"),
+            {"window": "30d"},
+            **self.auth_header,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.data
+        self.assertEqual(data["total_erc20_transfers"], 2)
+        self.assertEqual(data["unique_tokens"], 1)
+        self.assertEqual(len(data["top_tokens"]), 1)
+        self.assertEqual(data["top_tokens"][0]["transfer_count"], 2)
+        self.assertEqual(data["top_tokens"][0]["total_value"], "300")
+
+
+class TestSafeCreationsResampling(AnalyticsTestMixin, APITestCase):
+    """Verify week/month buckets are derived from cached day-grain series."""
+
+    def _seed_day_series(self, series):
+        payload = {"series": series, "computed_at": "2026-05-18T00:00:00+00:00"}
+        self.redis.set(AnalyticsService.REDIS_SAFE_CREATIONS, json.dumps(payload))
+
+    def test_day_passthrough(self):
+        self._seed_day_series(
+            [
+                {"period": "2026-05-04", "count": 3},
+                {"period": "2026-05-05", "count": 5},
+            ]
+        )
+        response = self.client.get(
+            reverse("v2:analytics:analytics-safe-creations"),
+            {"interval": "day"},
+            **self.auth_header,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.data,
+            [
+                {"period": "2026-05-04", "count": 3},
+                {"period": "2026-05-05", "count": 5},
+            ],
+        )
+
+    def test_week_resample(self):
+        # 2026-05-04 (Mon) and 2026-05-05 (Tue) → ISO week 2026-W19
+        # 2026-05-11 (Mon) → ISO week 2026-W20
+        self._seed_day_series(
+            [
+                {"period": "2026-05-04", "count": 3},
+                {"period": "2026-05-05", "count": 5},
+                {"period": "2026-05-11", "count": 7},
+            ]
+        )
+        response = self.client.get(
+            reverse("v2:analytics:analytics-safe-creations"),
+            {"interval": "week"},
+            **self.auth_header,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        # Two buckets total, counts summed within each ISO week
+        self.assertEqual(len(response.data), 2)
+        counts = sorted(row["count"] for row in response.data)
+        self.assertEqual(counts, [7, 8])
+
+    def test_month_resample(self):
+        self._seed_day_series(
+            [
+                {"period": "2026-04-30", "count": 2},
+                {"period": "2026-05-01", "count": 4},
+                {"period": "2026-05-31", "count": 1},
+            ]
+        )
+        response = self.client.get(
+            reverse("v2:analytics:analytics-safe-creations"),
+            {"interval": "month"},
+            **self.auth_header,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        # April → 2, May → 5
+        by_month = {row["period"][:7]: row["count"] for row in response.data}
+        self.assertEqual(by_month["2026-04"], 2)
+        self.assertEqual(by_month["2026-05"], 5)
+
+    def test_week_label_normalizes_to_monday(self):
+        # Series starts Tue 2026-05-05; the bucket label should still be
+        # Mon 2026-05-04 (Monday of ISO week 2026-W19), not the first
+        # day encountered in the source.
+        self._seed_day_series(
+            [
+                {"period": "2026-05-05", "count": 5},  # Tue
+                {"period": "2026-05-08", "count": 2},  # Fri, same week
+            ]
+        )
+        response = self.client.get(
+            reverse("v2:analytics:analytics-safe-creations"),
+            {"interval": "week"},
+            **self.auth_header,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, [{"period": "2026-05-04", "count": 7}])
+
+    def test_month_label_normalizes_to_first(self):
+        # Mid-month start; label must be 2026-05-01.
+        self._seed_day_series(
+            [
+                {"period": "2026-05-15", "count": 4},
+                {"period": "2026-05-22", "count": 1},
+            ]
+        )
+        response = self.client.get(
+            reverse("v2:analytics:analytics-safe-creations"),
+            {"interval": "month"},
+            **self.auth_header,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, [{"period": "2026-05-01", "count": 5}])
+
+    def test_date_range_filter(self):
+        self._seed_day_series(
+            [
+                {"period": "2026-04-15", "count": 1},
+                {"period": "2026-05-04", "count": 3},
+                {"period": "2026-05-20", "count": 9},
+            ]
+        )
+        response = self.client.get(
+            reverse("v2:analytics:analytics-safe-creations"),
+            {
+                "interval": "day",
+                "from": "2026-05-01T00:00:00Z",
+                "to": "2026-05-15T00:00:00Z",
+            },
+            **self.auth_header,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        # Only the 2026-05-04 entry falls inside the half-open window
+        self.assertEqual(response.data, [{"period": "2026-05-04", "count": 3}])
+
+    def test_cache_miss_triggers_sync_compute(self):
+        # No seed; ensure the view triggers compute_safe_creations_task itself
+        SafeContractFactory()
+        response = self.client.get(
+            reverse("v2:analytics:analytics-safe-creations"),
+            {"interval": "day"},
+            **self.auth_header,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertGreater(len(response.data), 0)
+        # Cache must now be populated
+        self.assertIsNotNone(self.redis.get(AnalyticsService.REDIS_SAFE_CREATIONS))
+
+
+class TestTvlSnapshotReadPath(AnalyticsTestMixin, APITestCase):
+    """`compute_tvl_task` is the canonical source — native + ERC20 are
+    computed atomically inside it. Cold reads return the empty payload
+    immediately and fire-and-forget dispatch the refresh."""
+
+    def test_tvl_payload_served_from_snapshot(self):
+        from django.utils import timezone
+
+        AnalyticsSnapshot.objects.create(
+            name="tvl",
+            payload={
+                "total_safes_with_balance": 99,
+                "native_balance_wei": "1",
+                "erc20_token_count": 2,
+                "top_tokens": [{"address": "0xabc"}],
+            },
+            computed_at=timezone.now(),
+        )
+        response = self.client.get(
+            reverse("v2:analytics:analytics-tvl"), **self.auth_header
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["total_safes_with_balance"], 99)
+        self.assertEqual(response.data["native_balance_wei"], "1")
+        self.assertEqual(response.data["erc20_token_count"], 2)
+        self.assertEqual(response.data["top_tokens"], [{"address": "0xabc"}])
+        self.assertIsNotNone(response.data["computed_at"])
+
+    def test_tvl_cold_snapshot_returns_empty(self):
+        # No `tvl` row yet — view returns the empty payload immediately
+        # and fire-and-forget dispatches a refresh. Patch the task to a
+        # no-op so the dispatch-on-miss path short-circuits and doesn't
+        # accidentally write the snapshot under eager mode.
+        with patch(
+            "safe_transaction_service.analytics.tasks.compute_tvl_task",
+            lambda: None,
+        ):
+            response = self.client.get(
+                reverse("v2:analytics:analytics-tvl"), **self.auth_header
+            )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["total_safes_with_balance"], 0)
+        self.assertEqual(response.data["native_balance_wei"], "0")
+        self.assertEqual(response.data["erc20_token_count"], 0)
+        self.assertEqual(response.data["top_tokens"], [])
+        self.assertIsNone(response.data["computed_at"])
+
+
+class TestSummaryCache(AnalyticsTestMixin, APITestCase):
+    @patch(
+        "safe_transaction_service.utils.ethereum.get_chain_id",
+        return_value=84532,
+    )
+    def test_summary_reads_from_snapshot(self, mock_chain_id):
+        from django.utils import timezone
+
+        snap_time = timezone.now()
+        AnalyticsSnapshot.objects.create(
+            name="summary",
+            payload={
+                "total_safes": 42,
+                "total_multisig_txs": 100,
+                "total_module_txs": 5,
+                "total_erc20_transfers": 200,
+                "total_erc721_transfers": 3,
+                "first_safe_created": "2025-01-01T00:00:00+00:00",
+                "last_safe_created": "2026-05-18T00:00:00+00:00",
+            },
+            computed_at=snap_time,
+        )
+        response = self.client.get(
+            reverse("v2:analytics:analytics-summary"), **self.auth_header
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.data
+        self.assertEqual(data["total_safes"], 42)
+        self.assertEqual(data["total_multisig_txs"], 100)
+        self.assertEqual(data["total_erc20_transfers"], 200)
+        self.assertEqual(data["chain_id"], 84532)
+        self.assertEqual(data["computed_at"], snap_time.isoformat())
+
+    @patch(
+        "safe_transaction_service.utils.ethereum.get_chain_id",
+        return_value=84532,
+    )
+    def test_summary_cold_cache_returns_empty_without_blocking(self, mock_chain_id):
+        """Cold snapshot read returns the empty payload IMMEDIATELY — no
+        25s `_redis_get_or_compute` poll, no 504. Under eager mode the
+        fire-and-forget dispatch then populates the snapshot
+        synchronously so a *second* request returns real data.
+
+        Headline behaviour change for operators (see
+        `flickering-honking-wand.md` Part 2 / §"Cold-deploy first request").
+        """
+        SafeContractFactory()
+        self.assertFalse(AnalyticsSnapshot.objects.filter(name="summary").exists())
+
+        first = self.client.get(
+            reverse("v2:analytics:analytics-summary"), **self.auth_header
+        )
+        self.assertEqual(first.status_code, status.HTTP_200_OK)
+        # Cold read: empty payload.
+        self.assertEqual(first.data["total_safes"], 0)
+        self.assertIsNone(first.data["computed_at"])
+        # Under eager mode the dispatched `.delay()` ran synchronously,
+        # so the snapshot is now populated and the SECOND request hits it.
+        self.assertTrue(
+            AnalyticsSnapshot.objects.filter(name="summary").exists(),
+            "fire-and-forget dispatch should have populated the snapshot",
+        )
+        second = self.client.get(
+            reverse("v2:analytics:analytics-summary"), **self.auth_header
+        )
+        self.assertEqual(second.status_code, status.HTTP_200_OK)
+        self.assertEqual(second.data["total_safes"], 1)
+        self.assertIsNotNone(second.data["computed_at"])
+
+
+class TestActiveSafesViewDailyTask(AnalyticsTestMixin, APITestCase):
+    """C7 read-path contract: the active_safes view must serve the
+    window-distinct count written by `compute_daily_metrics_task`, not a
+    sum of per-day DAU rows. A Safe touching activity in the 7d window
+    contributes exactly 1, regardless of how many days it was active."""
+
+    def test_serves_window_distinct_after_daily_task(self):
+        safe = SafeContractFactory()
+        MultisigTransactionFactory(safe=safe.address)
+
+        compute_daily_metrics_task(days_back=1)
+
+        response = self.client.get(
+            reverse("v2:analytics:analytics-active-safes"),
+            {"window": "7d"},
+            **self.auth_header,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["active_safes"], 1)
+        self.assertIsNotNone(response.data["computed_at"])
+
+
+class TestRollupReadPath(AnalyticsTestMixin, APITestCase):
+    """Spec §5: each of the four affected endpoints reads from rollups
+    when populated and falls back to the legacy live/cached path on a
+    cold rollup."""
+
+    def test_token_volume_served_from_rollup(self):
+        from datetime import timedelta
+
+        from django.utils import timezone
+
+        from eth_account import Account
+
+        from safe_transaction_service.analytics.models import DailyTokenVolume
+
+        token = Account.create().address
+        today = timezone.now().date()
+        DailyTokenVolume.objects.create(
+            date=today - timedelta(days=1),
+            token_address=token,
+            transfer_count=3,
+            transfer_value=900,
+        )
+        DailyTokenVolume.objects.create(
+            date=today - timedelta(days=2),
+            token_address=token,
+            transfer_count=2,
+            transfer_value=100,
+        )
+
+        response = self.client.get(
+            reverse("v2:analytics:analytics-token-volume"),
+            {"window": "30d"},
+            **self.auth_header,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["total_erc20_transfers"], 5)
+        self.assertEqual(response.data["unique_tokens"], 1)
+        self.assertEqual(response.data["top_tokens"][0]["transfer_count"], 5)
+        self.assertEqual(response.data["top_tokens"][0]["total_value"], "1000")
+
+    def test_token_volume_cold_window_falls_back_to_live(self):
+        from eth_account import Account
+
+        token = Account.create().address
+        ERC20TransferFactory(address=token, value=100)
+
+        response = self.client.get(
+            reverse("v2:analytics:analytics-token-volume"),
+            {"window": "30d"},
+            **self.auth_header,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["total_erc20_transfers"], 1)
+        # Live path doesn't tag source.
+        self.assertNotIn("source", response.data)
+
+    def test_active_safes_served_from_rollup(self):
+        from datetime import timedelta
+
+        from django.utils import timezone
+
+        from eth_account import Account
+
+        from safe_transaction_service.analytics.models import DailyActiveSafe
+
+        today = timezone.now().date()
+        addr1 = Account.create().address
+        addr2 = Account.create().address
+        DailyActiveSafe.objects.create(
+            date=today - timedelta(days=1), safe_address=addr1
+        )
+        DailyActiveSafe.objects.create(
+            date=today - timedelta(days=2), safe_address=addr1
+        )
+        DailyActiveSafe.objects.create(
+            date=today - timedelta(days=2), safe_address=addr2
+        )
+
+        response = self.client.get(
+            reverse("v2:analytics:analytics-active-safes"),
+            {"window": "7d"},
+            **self.auth_header,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        # addr1 counted once even though it appears on two days.
+        self.assertEqual(response.data["active_safes"], 2)
+
+    def test_active_safes_cold_window_falls_back_to_cached(self):
+        # Pre-populate the legacy Redis key the fallback reads from.
+        self.redis.set(
+            AnalyticsService.REDIS_ACTIVE_SAFES_PREFIX + "30d",
+            json.dumps(
+                {
+                    "window": "30d",
+                    "active_safes": 7,
+                    "computed_at": "2026-05-18T00:00:00+00:00",
+                }
+            ),
+        )
+
+        response = self.client.get(
+            reverse("v2:analytics:analytics-active-safes"),
+            {"window": "30d"},
+            **self.auth_header,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["active_safes"], 7)
+
+    def test_safe_creations_served_from_rollup(self):
+        from datetime import timedelta
+
+        from django.utils import timezone
+
+        from safe_transaction_service.analytics.models import DailySafeCreation
+
+        today = timezone.now().date()
+        DailySafeCreation.objects.create(date=today - timedelta(days=1), count=4)
+        DailySafeCreation.objects.create(date=today - timedelta(days=2), count=1)
+
+        response = self.client.get(
+            reverse("v2:analytics:analytics-safe-creations"),
+            {"interval": "day"},
+            **self.auth_header,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        # Two day rows, total = 5
+        self.assertEqual(len(response.data), 2)
+        self.assertEqual(sum(r["count"] for r in response.data), 5)
+
+    def test_safe_app_txs_served_from_rollup(self):
+        from datetime import timedelta
+
+        from django.utils import timezone
+
+        from safe_transaction_service.analytics.models import DailySafeAppTx
+
+        today = timezone.now().date()
+        DailySafeAppTx.objects.create(
+            date=today - timedelta(days=1),
+            origin_name="App1",
+            origin_url="https://app1.example",
+            tx_count=4,
+        )
+        DailySafeAppTx.objects.create(
+            date=today - timedelta(days=10),
+            origin_name="App1",
+            origin_url="https://app1-older.example",
+            tx_count=1,
+        )
+        DailySafeAppTx.objects.create(
+            date=today - timedelta(days=2),
+            origin_name="App2",
+            origin_url="https://app2.example",
+            tx_count=2,
+        )
+
+        response = self.client.get(
+            reverse("v2:analytics:analytics-multisig-txs-by-origin"),
+            **self.auth_header,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        by_name = {r["name"]: r for r in response.data}
+        # App1 total = 5 (4 from last week + 1 from 10 days ago)
+        self.assertEqual(by_name["App1"]["total_tx"], 5)
+        self.assertEqual(by_name["App1"]["tx_last_week"], 4)
+        self.assertEqual(by_name["App1"]["tx_last_month"], 5)
+        self.assertEqual(by_name["App2"]["total_tx"], 2)
+        # URL comes straight from the rollup, no history_* lookup.
+        # Most-recent non-empty URL wins for App1.
+        self.assertEqual(by_name["App1"]["url"], "https://app1.example")
+        self.assertEqual(by_name["App2"]["url"], "https://app2.example")
+
+    def test_safe_app_txs_cold_window_falls_back_to_redis(self):
+        self.redis.set(
+            AnalyticsService.REDIS_TRANSACTIONS_PER_SAFE_APP,
+            json.dumps(
+                [
+                    {
+                        "name": "Legacy",
+                        "url": "https://legacy",
+                        "total_tx": 9,
+                        "tx_last_week": 3,
+                        "tx_last_month": 9,
+                        "tx_last_year": 9,
+                    }
+                ]
+            ),
+        )
+
+        response = self.client.get(
+            reverse("v2:analytics:analytics-multisig-txs-by-origin"),
+            **self.auth_header,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data[0]["name"], "Legacy")
+        self.assertEqual(response.data[0]["total_tx"], 9)
+
+
+class TestTxVolumeDailyMetricSource(AnalyticsTestMixin, APITestCase):
+    """C7 read-path: when DailyMetric covers the requested window, the
+    response should sum the persisted rows (and mark `source=daily_metric`).
+    When coverage is sparse, the live ORM path is the fallback."""
+
+    def test_returns_daily_metric_sum_when_table_populated(self):
+        from datetime import timedelta
+
+        from django.utils import timezone
+
+        from safe_transaction_service.analytics.models import DailyMetric
+
+        # Populate 8 rows covering the 7d window (date < today, date >= today-7).
+        today = timezone.now().date()
+        for offset in range(1, 9):
+            DailyMetric.objects.create(
+                date=today - timedelta(days=offset),
+                multisig_txs_executed=2,
+                module_txs=1,
+                erc20_transfers=3,
+                native_value_wei=100,
+                multisig_txs_proposed=4,
+                confirmations_count=6,
+                confirmed_tx_count=3,
+                computed_at=timezone.now(),
+            )
+
+        response = self.client.get(
+            reverse("v2:analytics:analytics-tx-volume"),
+            {"window": "7d"},
+            **self.auth_header,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.data
+        # 7 days of 2 multisig + 1 module = 14 + 7 = 21 from the table
+        # rows in the [today-7, today) range. Row at offset=8 is excluded.
+        self.assertEqual(data["executed_multisig_txs"], 14)
+        self.assertEqual(data["module_txs"], 7)
+        self.assertEqual(data["total_value_wei"], "700")
+        # New rollup columns: proposed = 4 × 7 = 28; avg_confirmations =
+        # SUM(confirmations_count) / SUM(confirmed_tx_count) = 42 / 21 = 2.0
+        self.assertEqual(data["total_multisig_txs"], 28)
+        self.assertEqual(data["avg_confirmations"], 2.0)
+        self.assertEqual(data["avg_confirmations_approximation"], "per-tx-day")
+        self.assertEqual(data["coverage_days"], 7)
+        self.assertEqual(data.get("source"), "daily_metric")
+
+    def test_sparse_rollup_returns_zeros_not_live_count(self):
+        """No DailyMetric rows → response must return zeros and
+        `coverage_days=0` rather than falling back to a live ORM count.
+        The live path was removed because it could not finish in 30s on
+        Base; sparse coverage is surfaced honestly via `coverage_days`.
+        """
+        # Seed live data the legacy fallback would have summed — it
+        # must NOT show up in the response now.
+        MultisigTransactionFactory(value=1000)
+        MultisigTransactionFactory(value=2000)
+
+        response = self.client.get(
+            reverse("v2:analytics:analytics-tx-volume"),
+            {"window": "30d"},
+            **self.auth_header,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.data
+        self.assertEqual(data["total_multisig_txs"], 0)
+        self.assertEqual(data["executed_multisig_txs"], 0)
+        self.assertEqual(data["total_value_wei"], "0")
+        self.assertEqual(data["avg_confirmations"], 0.0)
+        self.assertEqual(data["coverage_days"], 0)
+        self.assertEqual(data.get("source"), "daily_metric")
+
+
+class TestActiveOwnersRollupReadPath(AnalyticsTestMixin, APITestCase):
+    """`active-owners` reads `DailyActiveOwner` directly — no
+    `SafeLastStatus` lookup at request time (see
+    `flickering-honking-wand.md` Part 1)."""
+
+    def test_active_owners_served_from_rollup_via_daily_active_owner(self):
+        from datetime import timedelta
+
+        from django.utils import timezone
+
+        from eth_account import Account
+
+        from safe_transaction_service.analytics.models import DailyActiveOwner
+
+        today = timezone.now().date()
+        owner1 = Account.create().address
+        owner2 = Account.create().address
+        DailyActiveOwner.objects.create(
+            date=today - timedelta(days=1), owner_address=owner1
+        )
+        # Same owner on a different day — must count once.
+        DailyActiveOwner.objects.create(
+            date=today - timedelta(days=2), owner_address=owner1
+        )
+        DailyActiveOwner.objects.create(
+            date=today - timedelta(days=2), owner_address=owner2
+        )
+
+        response = self.client.get(
+            reverse("v2:analytics:analytics-active-owners"),
+            {"window": "7d"},
+            **self.auth_header,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["active_owners"], 2)
+        self.assertIsNotNone(response.data["computed_at"])
+
+
+class TestSnapshotReadPath(AnalyticsTestMixin, APITestCase):
+    """The four current-state endpoints read from
+    `analytics_analyticssnapshot`. Each test verifies (a) snapshot-served
+    response, (b) cold-snapshot response is empty (not a 504)."""
+
+    def _make_snapshot(self, name: str, payload: dict):
+        from django.utils import timezone
+
+        AnalyticsSnapshot.objects.create(
+            name=name, payload=payload, computed_at=timezone.now()
+        )
+
+    def test_safe_segments_served_from_snapshot(self):
+        self._make_snapshot(
+            "safe_segments",
+            {
+                "personal": 3,
+                "team": 2,
+                "enterprise": 1,
+                "with_modules": 1,
+                "avg_threshold": 1.5,
+                "avg_owners": 2.0,
+            },
+        )
+        response = self.client.get(
+            reverse("v2:analytics:analytics-safe-segments"), **self.auth_header
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["personal"], 3)
+        self.assertEqual(response.data["team"], 2)
+        self.assertEqual(response.data["enterprise"], 1)
+        self.assertIsNotNone(response.data["computed_at"])
+
+    def test_tvl_served_from_snapshot(self):
+        self._make_snapshot(
+            "tvl",
+            {
+                "total_safes_with_balance": 7,
+                "native_balance_wei": "100",
+                "erc20_token_count": 3,
+                "top_tokens": [],
+            },
+        )
+        response = self.client.get(
+            reverse("v2:analytics:analytics-tvl"), **self.auth_header
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["total_safes_with_balance"], 7)
+        self.assertEqual(response.data["native_balance_wei"], "100")
+        self.assertEqual(response.data["erc20_token_count"], 3)
+        self.assertIsNotNone(response.data["computed_at"])

--- a/safe_transaction_service/analytics/urls_v2.py
+++ b/safe_transaction_service/analytics/urls_v2.py
@@ -9,5 +9,45 @@ urlpatterns = [
         "multisig-transactions/by-origin/",
         views_v2.AnalyticsMultisigTxsByOriginListView.as_view(),
         name="analytics-multisig-txs-by-origin",
-    )
+    ),
+    path(
+        "summary/",
+        views_v2.AnalyticsSummaryView.as_view(),
+        name="analytics-summary",
+    ),
+    path(
+        "active-safes/",
+        views_v2.AnalyticsActiveSafesView.as_view(),
+        name="analytics-active-safes",
+    ),
+    path(
+        "safe-creations/",
+        views_v2.AnalyticsSafeCreationsView.as_view(),
+        name="analytics-safe-creations",
+    ),
+    path(
+        "active-owners/",
+        views_v2.AnalyticsActiveOwnersView.as_view(),
+        name="analytics-active-owners",
+    ),
+    path(
+        "tx-volume/",
+        views_v2.AnalyticsTxVolumeView.as_view(),
+        name="analytics-tx-volume",
+    ),
+    path(
+        "safe-segments/",
+        views_v2.AnalyticsSafeSegmentsView.as_view(),
+        name="analytics-safe-segments",
+    ),
+    path(
+        "tvl/",
+        views_v2.AnalyticsTvlView.as_view(),
+        name="analytics-tvl",
+    ),
+    path(
+        "token-volume/",
+        views_v2.AnalyticsTokenVolumeView.as_view(),
+        name="analytics-token-volume",
+    ),
 ]

--- a/safe_transaction_service/analytics/views_v2.py
+++ b/safe_transaction_service/analytics/views_v2.py
@@ -1,16 +1,18 @@
+from django.utils.dateparse import parse_datetime
+
+from drf_spectacular.utils import extend_schema
 from rest_framework.authentication import TokenAuthentication
-from rest_framework.generics import ListAPIView
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from safe_transaction_service.analytics.services.analytics_service import (
     get_analytics_service,
 )
 
 
-class AnalyticsMultisigTxsByOriginListView(ListAPIView):
-    pagination_class = None
+class AnalyticsMultisigTxsByOriginListView(APIView):
     swagger_schema = None
     renderer_classes = (JSONRenderer,)
     authentication_classes = [TokenAuthentication]
@@ -19,3 +21,138 @@ class AnalyticsMultisigTxsByOriginListView(ListAPIView):
     def get(self, request, format=None):
         analytics_service = get_analytics_service()
         return Response(analytics_service.get_safe_transactions_per_safe_app())
+
+
+class AnalyticsSummaryView(APIView):
+    """A.1 — Fleet-level summary metrics (direct query)."""
+
+    swagger_schema = None
+    renderer_classes = (JSONRenderer,)
+    authentication_classes = [TokenAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    @extend_schema(exclude=True)
+    def get(self, request, format=None):
+        analytics_service = get_analytics_service()
+        return Response(analytics_service.get_summary())
+
+
+class AnalyticsActiveSafesView(APIView):
+    """A.2 — Active Safes count by window (Redis-cached)."""
+
+    swagger_schema = None
+    renderer_classes = (JSONRenderer,)
+    authentication_classes = [TokenAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    @extend_schema(exclude=True)
+    def get(self, request, format=None):
+        window = request.query_params.get("window", "30d")
+        if window not in ("7d", "30d", "90d"):
+            return Response(
+                {"error": "window must be one of: 7d, 30d, 90d"}, status=400
+            )
+        analytics_service = get_analytics_service()
+        return Response(analytics_service.get_active_safes(window))
+
+
+class AnalyticsSafeCreationsView(APIView):
+    """A.3 — Safe creations time series (direct query)."""
+
+    swagger_schema = None
+    renderer_classes = (JSONRenderer,)
+    authentication_classes = [TokenAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    @extend_schema(exclude=True)
+    def get(self, request, format=None):
+        interval = request.query_params.get("interval", "day")
+        if interval not in ("day", "week", "month"):
+            return Response(
+                {"error": "interval must be one of: day, week, month"}, status=400
+            )
+        date_from = request.query_params.get("from")
+        date_to = request.query_params.get("to")
+        parsed_from = parse_datetime(date_from) if date_from else None
+        parsed_to = parse_datetime(date_to) if date_to else None
+        analytics_service = get_analytics_service()
+        return Response(
+            analytics_service.get_safe_creations(parsed_from, parsed_to, interval)
+        )
+
+
+class AnalyticsActiveOwnersView(APIView):
+    """A.4 — Active owners by window (Redis-cached)."""
+
+    swagger_schema = None
+    renderer_classes = (JSONRenderer,)
+    authentication_classes = [TokenAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    @extend_schema(exclude=True)
+    def get(self, request, format=None):
+        window = request.query_params.get("window", "30d")
+        if window not in ("7d", "30d", "90d"):
+            return Response(
+                {"error": "window must be one of: 7d, 30d, 90d"}, status=400
+            )
+        analytics_service = get_analytics_service()
+        return Response(analytics_service.get_active_owners(window))
+
+
+class AnalyticsTxVolumeView(APIView):
+    """A.5 — TX volume metrics by window (direct query)."""
+
+    swagger_schema = None
+    renderer_classes = (JSONRenderer,)
+    authentication_classes = [TokenAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    @extend_schema(exclude=True)
+    def get(self, request, format=None):
+        window = request.query_params.get("window", "30d")
+        analytics_service = get_analytics_service()
+        return Response(analytics_service.get_tx_volume(window))
+
+
+class AnalyticsSafeSegmentsView(APIView):
+    """A.6 — Safe segments by owner count (Redis-cached)."""
+
+    swagger_schema = None
+    renderer_classes = (JSONRenderer,)
+    authentication_classes = [TokenAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    @extend_schema(exclude=True)
+    def get(self, request, format=None):
+        analytics_service = get_analytics_service()
+        return Response(analytics_service.get_safe_segments())
+
+
+class AnalyticsTvlView(APIView):
+    """A.7 — TVL (approximate via net-flow, Redis-cached)."""
+
+    swagger_schema = None
+    renderer_classes = (JSONRenderer,)
+    authentication_classes = [TokenAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    @extend_schema(exclude=True)
+    def get(self, request, format=None):
+        analytics_service = get_analytics_service()
+        return Response(analytics_service.get_tvl())
+
+
+class AnalyticsTokenVolumeView(APIView):
+    """A.8 — Token volume metrics by window (direct query)."""
+
+    swagger_schema = None
+    renderer_classes = (JSONRenderer,)
+    authentication_classes = [TokenAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    @extend_schema(exclude=True)
+    def get(self, request, format=None):
+        window = request.query_params.get("window", "30d")
+        analytics_service = get_analytics_service()
+        return Response(analytics_service.get_token_volume(window))

--- a/safe_transaction_service/history/management/commands/setup_service.py
+++ b/safe_transaction_service/history/management/commands/setup_service.py
@@ -160,6 +160,44 @@ TASKS = [
         description="Run query to get number of transactions grouped by safe-app (Every sunday at 00:00)",
         cron=CronDefinition(minute=0, hour=0, day_of_week=0),  # Every sunday 0 0 * * 0
     ),
+    CeleryTaskConfiguration(
+        name="safe_transaction_service.analytics.tasks.compute_summary_task",
+        description="Refresh /summary/ snapshot (daily at 02:00)",
+        cron=CronDefinition(minute=0, hour=2),  # Daily at 02:00 - 0 2 * * *
+    ),
+    CeleryTaskConfiguration(
+        name="safe_transaction_service.analytics.tasks.compute_daily_metrics_task",
+        description=(
+            "Compute incremental DailyMetric row + refresh active_* window "
+            "caches (daily at 01:00)"
+        ),
+        cron=CronDefinition(minute=0, hour=1),  # Daily at 01:00 - 0 1 * * *
+    ),
+    CeleryTaskConfiguration(
+        name="safe_transaction_service.analytics.tasks.compute_active_safes_task",
+        description="Precompute active Safes for 7d/30d/90d (daily at 02:30)",
+        cron=CronDefinition(minute=30, hour=2),  # Daily at 02:30 - 30 2 * * *
+    ),
+    CeleryTaskConfiguration(
+        name="safe_transaction_service.analytics.tasks.compute_active_owners_task",
+        description="Precompute active owners for 7d/30d/90d (daily at 02:45)",
+        cron=CronDefinition(minute=45, hour=2),  # Daily at 02:45 - 45 2 * * *
+    ),
+    CeleryTaskConfiguration(
+        name="safe_transaction_service.analytics.tasks.compute_safe_segments_task",
+        description="Precompute Safe segments by owner count (daily at 03:00)",
+        cron=CronDefinition(minute=0, hour=3),  # Daily at 03:00 - 0 3 * * *
+    ),
+    CeleryTaskConfiguration(
+        name="safe_transaction_service.analytics.tasks.compute_tvl_task",
+        description="Precompute TVL aggregates (daily at 03:15)",
+        cron=CronDefinition(minute=15, hour=3),  # Daily at 03:15 - 15 3 * * *
+    ),
+    CeleryTaskConfiguration(
+        name="safe_transaction_service.analytics.tasks.compute_safe_creations_task",
+        description="Compute Safe creations day-grain time series (daily at 04:30)",
+        cron=CronDefinition(minute=30, hour=4),  # 30 4 * * *
+    ),
 ]
 
 

--- a/safe_transaction_service/history/views.py
+++ b/safe_transaction_service/history/views.py
@@ -77,6 +77,10 @@ class AboutView(APIView):
 
     @method_decorator(cache_page(5 * 60))  # 5 minutes
     def get(self, request, format=None):
+        ethereum_node_url = (
+            settings.ETHEREUM_NODE_URL if not settings.HIDE_ETHEREUM_RPC else None
+        )
+
         content = {
             "name": "Safe Transaction Service",
             "version": __version__,


### PR DESCRIPTION
* feat: replace RPC balance calls with DB aggregation on InternalTx

Individual RPC get_balance() calls caused Celery task timeouts on networks with 100K+ Safes (e.g. Berachain). Replace with batched SQL aggregation on the already-indexed InternalTx table, computing SUM(incoming) - SUM(outgoing) per Safe in seconds instead of hours.

- Delete _get_native_balances_multicall() and _calculate_native_balances_batched()
- Add _calculate_native_balances_from_db() with batched SQL (5000 addresses/batch)
- Change schedule from monthly to daily at 02:00
- Add 8 tests for the new balance calculation function



* style: apply ruff lint and format fixes

Auto-fixes from `pre-commit run --all-files` (ruff + ruff-format) and manual cleanup of remaining lint issues in `manual_insert_safe_account_to_db`:
- `raise ... from e` inside except clauses (B904)
- replace bare `except:` with `except Exception:` (E722)
- strip trailing whitespace in docstrings

Also adds missing `analytics/tests/__init__.py` so pytest can resolve relative imports in `test_views_v2.py`.



* WIP: 8 new /v1/analytics/* endpoints + Redis-cached precomputation

Backs up local work before handover. Teammate may rebase/split before opening the PR. See proto-agi/research/safe-analytics/handover-2026-05.md for context. Implements blueprint Section 7.1 (Tier 2 endpoints).

NEW ENDPOINTS (8) registered in analytics/urls_v2.py:
  GET /v1/analytics/summary/         A.1 direct query
  GET /v1/analytics/active-safes/    A.2 Redis-cached (?window=7d|30d|90d)
  GET /v1/analytics/safe-creations/  A.3 direct query (?from=&to=&interval=)
  GET /v1/analytics/active-owners/   A.4 Redis-cached (?window=30d)
  GET /v1/analytics/tx-volume/       A.5 direct query (?window=30d)
  GET /v1/analytics/safe-segments/   A.6 Redis-cached
  GET /v1/analytics/tvl/             A.7 Redis-cached (SKELETON — see gaps)
  GET /v1/analytics/token-volume/    A.8 direct query (?window=30d)

All endpoints require TokenAuthentication (consistent with existing analytics endpoints by Denis/Nikita).

FILES (1046 insertions / 21 deletions):
  - analytics/urls_v2.py (+40)            — 8 new URL routes
  - analytics/views_v2.py (+145)          — 8 new view classes
  - analytics/services/analytics_service.py (+201) — direct-query implementations
                                            + Redis-cached read stubs
  - analytics/tasks.py (+248)             — Celery precomputation tasks for
                                            active-safes, active-owners, segments, tvl
  - analytics/tests/test_views_v2.py (+355) — view tests
  - analytics/serializers.py (NEW)        — response serializers

KNOWN GAPS vs blueprint Section 7.1:
- TVL endpoint is a SKELETON: returns a Redis-cached structure ({total_safes_with_balance, native_balance_wei, erc20_token_count, top_tokens, computed_at}) but the precomputation task (in tasks.py) has NOT been validated against real production data. No external price feed (CoinGecko/DeFiLlama) is integrated; this is NOT USD- denominated TVL — it returns raw native + per-token counts.
- /v1/analytics/retention-cohorts/ (Phase 3) NOT implemented.
- Materialized views (mv_daily_safe_creations, mv_active_safes, mv_safe_segments) NOT created; replaced by Celery-driven Redis precomputation. tasks.py defines the scheduled tasks but production Celery beat config needs to register them.

PRE-EXISTING WORK NOT FROM THIS BRANCH:
- /v1/analytics/multisig-transactions/by-origin/ — pre-existing upstream
- /v1/analytics/safe-statistics/ — separate WIP effort by Denis Smolonski
  + Nikita Zasimuk, already merged to production. Never utilized; this branch's /summary/ endpoint supersedes it functionally.

NOT YET ROLLED OUT to 44+ PRD TX Service instances. Client-specific forks that need cherry-pick after merge:
  AstarNetwork/safe-transaction-service@astar
  bobanetwork/safe-transaction-service@production
  cronos-safe/safe-transaction-service@cronos (may not be compatible with
  v4.37.0 schema — history_saferelevancetransaction may not exist)



* feat(analytics): improvements for large data bases

* perf(analytics): address PR #21 review findings for large-DB hot paths

- Replace OFFSET/LIMIT loops over SafeContract with a keyset cursor helper (`_iter_safe_addresses_keyset`) in `tasks.py`; fixes O(N²) pagination on multi-million-Safe chains.
- Rewrite `_safe_addresses_for_prefix` to filter by an indexed bytea PK range instead of streaming every Safe row to Python for each of the 16 shards.
- Collapse `_erc20_active_safe_addrs_between`'s per-Safe EXISTS batch loop into a single JOIN over the day's transfers (drops the now- unused `_ERC20_ACTIVE_BETWEEN_BATCH_SQL`).
- Broaden `relaxed_statement_timeout`'s reset-finally to catch `DatabaseError` so an aborted-transaction `InternalError` can no longer mask the original timeout.
- Switch `approx_count_or_exact` to `oid = %s::regclass` (schema-safe lookup) with `ProgrammingError` fallback to exact COUNT(*) for not-yet-created tables.
- Add focused tests: keyset boundary correctness with batch_size=2, bounded-JOIN inclusion/exclusion semantics.



---------

### Make sure these boxes are checked! 📦✅

- [ ] You ran `./run_tests.sh`
- [ ] You ran `pre-commit run -a`
- [ ] If you want to add your network to `setup_service.py`, provide a link to your
    [safe-deployments PR](https://github.com/safe-global/safe-deployments/pulls) and check network name
    exists in [safe-eth-py](https://github.com/safe-global/safe-eth-py/blob/master/gnosis/eth/ethereum_network.py)

### What was wrong? 👾

Closes #

### How was it fixed? 🎯
